### PR TITLE
Fix JSON body handling in HTTP requests

### DIFF
--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -217,7 +217,9 @@ class HaapiApiCaller:
 
         try:
             tpl = template.Template(template_str, self.hass)
-            return tpl.async_render()
+            rendered = tpl.async_render()
+            # Convert to string in case it returns a Wrapper object
+            return str(rendered)
         except TemplateError as err:
             _LOGGER.error("Error rendering template: %s", err)
             return template_str

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import ssl
 from datetime import datetime
@@ -328,13 +329,30 @@ class HaapiApiCaller:
                 async with async_timeout.timeout(timeout):
                     connector = aiohttp.TCPConnector(ssl=ssl_context if ssl_context else True)
                     async with aiohttp.ClientSession(connector=connector) as session:
-                        async with session.request(
-                            method=method,
-                            url=url,
-                            headers=headers if headers else None,
-                            data=body if body else None,
-                            auth=auth,
-                        ) as response:
+                        # Prepare request kwargs
+                        request_kwargs = {
+                            "method": method,
+                            "url": url,
+                            "headers": headers if headers else None,
+                            "auth": auth,
+                        }
+
+                        # Handle body based on content type
+                        if body:
+                            if content_type and "application/json" in content_type.lower():
+                                # For JSON content, parse and use json parameter
+                                try:
+                                    request_kwargs["json"] = json.loads(body)
+                                except (json.JSONDecodeError, ValueError) as e:
+                                    _LOGGER.warning(
+                                        "Failed to parse body as JSON, sending as text: %s", e
+                                    )
+                                    request_kwargs["data"] = body
+                            else:
+                                # For other content types, send as data (form-encoded, text, etc.)
+                                request_kwargs["data"] = body
+
+                        async with session.request(**request_kwargs) as response:
                             self._last_response_code = response.status
                             self._last_fetch_time = dt_util.utcnow()
                             response_body = await response.text()

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -343,7 +343,7 @@ class HaapiApiCaller:
                                 # For JSON content, parse and use json parameter
                                 try:
                                     request_kwargs["json"] = json.loads(body)
-                                except (json.JSONDecodeError, ValueError) as e:
+                                except json.JSONDecodeError as e:
                                     _LOGGER.warning(
                                         "Failed to parse body as JSON, sending as text: %s", e
                                     )

--- a/custom_components/haapi/manifest.json
+++ b/custom_components/haapi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nasawa/HAAPI/issues",
   "requirements": [],
-  "version": "2.5.0"
+  "version": "2.6.0"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for HAAPI tests."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from homeassistant.const import CONF_NAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for HAAPI tests."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.const import CONF_NAME
@@ -37,6 +37,13 @@ from custom_components.haapi.const import (
 
 
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def mock_tcp_connector():
+    """Mock aiohttp.TCPConnector to avoid socket creation."""
+    with patch("aiohttp.TCPConnector", return_value=Mock()):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -256,7 +256,7 @@ async def test_api_call_with_json_body(hass: HomeAssistant, mock_endpoint_config
     call_kwargs = mock_session.request.call_args[1]
     assert "json" in call_kwargs
     assert call_kwargs["json"] == {"key": "value", "number": 42}
-    assert "data" not in call_kwargs or call_kwargs["data"] is None
+    assert call_kwargs.get("data") is None
 
 
 async def test_api_call_with_form_data(hass: HomeAssistant, mock_endpoint_config) -> None:
@@ -289,7 +289,7 @@ async def test_api_call_with_form_data(hass: HomeAssistant, mock_endpoint_config
     call_kwargs = mock_session.request.call_args[1]
     assert "data" in call_kwargs
     assert call_kwargs["data"] == "key=value&number=42"
-    assert "json" not in call_kwargs or call_kwargs["json"] is None
+    assert call_kwargs.get("json") is None
 
 
 async def test_api_call_with_invalid_json_body(hass: HomeAssistant, mock_endpoint_config) -> None:
@@ -322,4 +322,4 @@ async def test_api_call_with_invalid_json_body(hass: HomeAssistant, mock_endpoin
     call_kwargs = mock_session.request.call_args[1]
     assert "data" in call_kwargs
     assert call_kwargs["data"] == "not valid json"
-    assert "json" not in call_kwargs or call_kwargs["json"] is None
+    assert call_kwargs.get("json") is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -224,3 +224,102 @@ async def test_api_call_with_ssl_disabled(hass: HomeAssistant, mock_endpoint_con
     assert api_caller.last_response_code == 200
     # Verify that TCPConnector was created with SSL context
     assert mock_session.request.called
+
+
+async def test_api_call_with_json_body(hass: HomeAssistant, mock_endpoint_config) -> None:
+    """Test API call with JSON body is sent correctly."""
+    from custom_components.haapi import HaapiApiCaller
+
+    # Configure endpoint with JSON body
+    mock_endpoint_config["method"] = "POST"
+    mock_endpoint_config["content_type"] = "application/json"
+    mock_endpoint_config["body"] = '{"key": "value", "number": 42}'
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.text = AsyncMock(return_value="Success")
+    mock_response.headers = {}
+
+    mock_session = AsyncMock()
+    mock_session.request = AsyncMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    save_callback = AsyncMock()
+    api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        await api_caller.async_call_api()
+
+    assert api_caller.last_response_code == 200
+    # Verify that request was called with json parameter, not data
+    call_kwargs = mock_session.request.call_args[1]
+    assert "json" in call_kwargs
+    assert call_kwargs["json"] == {"key": "value", "number": 42}
+    assert "data" not in call_kwargs or call_kwargs["data"] is None
+
+
+async def test_api_call_with_form_data(hass: HomeAssistant, mock_endpoint_config) -> None:
+    """Test API call with form data is sent as data parameter."""
+    from custom_components.haapi import HaapiApiCaller
+
+    # Configure endpoint with form data
+    mock_endpoint_config["method"] = "POST"
+    mock_endpoint_config["content_type"] = "application/x-www-form-urlencoded"
+    mock_endpoint_config["body"] = "key=value&number=42"
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.text = AsyncMock(return_value="Success")
+    mock_response.headers = {}
+
+    mock_session = AsyncMock()
+    mock_session.request = AsyncMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    save_callback = AsyncMock()
+    api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        await api_caller.async_call_api()
+
+    assert api_caller.last_response_code == 200
+    # Verify that request was called with data parameter, not json
+    call_kwargs = mock_session.request.call_args[1]
+    assert "data" in call_kwargs
+    assert call_kwargs["data"] == "key=value&number=42"
+    assert "json" not in call_kwargs or call_kwargs["json"] is None
+
+
+async def test_api_call_with_invalid_json_body(hass: HomeAssistant, mock_endpoint_config) -> None:
+    """Test API call with invalid JSON body falls back to sending as data."""
+    from custom_components.haapi import HaapiApiCaller
+
+    # Configure endpoint with invalid JSON
+    mock_endpoint_config["method"] = "POST"
+    mock_endpoint_config["content_type"] = "application/json"
+    mock_endpoint_config["body"] = "not valid json"
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.text = AsyncMock(return_value="Success")
+    mock_response.headers = {}
+
+    mock_session = AsyncMock()
+    mock_session.request = AsyncMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    save_callback = AsyncMock()
+    api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        await api_caller.async_call_api()
+
+    assert api_caller.last_response_code == 200
+    # Verify that invalid JSON falls back to data parameter
+    call_kwargs = mock_session.request.call_args[1]
+    assert "data" in call_kwargs
+    assert call_kwargs["data"] == "not valid json"
+    assert "json" not in call_kwargs or call_kwargs["json"] is None


### PR DESCRIPTION
Previously, all HTTP request bodies were sent as URL-encoded form data regardless of the Content-Type setting. This caused issues when APIs expected JSON payloads.

Changes:
- Modified async_call_api() to check content_type before sending body
- When content_type is "application/json", parse body and use json parameter
- For other content types, continue using data parameter (backward compatible)
- Added graceful fallback if JSON parsing fails
- Added comprehensive tests for JSON, form data, and invalid JSON scenarios
- Added TCPConnector mock to test fixtures to avoid socket creation

This fix ensures APIs expecting JSON receive properly formatted JSON while maintaining backward compatibility for form-encoded and other content types.

Version bumped to 2.6.0