### PR TITLE
Add integration-specific triggers (HA 2026.7+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ Thumbs.db
 # Home Assistant
 *.log
 .claude-tools
+
+.venv/

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Each trigger can target one or more endpoint devices, or be left untargeted to f
 ```yaml
 automation:
   - alias: "Notify when API result changes"
-    triggers:
+    trigger:
       - trigger: haapi.response_changed
         target:
           device_id: <your HAAPI endpoint device>
-    actions:
+    action:
       - action: notify.mobile_app
         data:
           message: "API changed: {{ trigger.body }}"
@@ -155,9 +155,9 @@ automation:
 ```yaml
 automation:
   - alias: "Alert on API failure"
-    triggers:
+    trigger:
       - trigger: haapi.call_failed
-    actions:
+    action:
       - action: notify.mobile_app
         data:
           message: "{{ trigger.endpoint_name }} failed (status {{ trigger.status }})"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A universal API integration framework for Home Assistant 2025.11+ where each "de
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Entities](#entities)
+- [Triggers](#triggers)
 - [Usage](#usage)
   - [Quick Start Examples](#quick-start-examples)
   - [Template Support](#template-support)
@@ -27,6 +28,7 @@ A universal API integration framework for Home Assistant 2025.11+ where each "de
 - **Template Support**: Use Jinja2 templates in URLs, headers, and request bodies
 - **Multiple Auth Types**: None, Basic, Bearer Token, or API Key authentication
 - **Response Storage**: Capture HTTP status codes, response bodies, and headers
+- **Integration Triggers**: React to call completions directly in automations (success, failure, response changed, status changed) — no `delay` + state-watch workarounds
 - **Modern HA Standards**: Built with config flow and proper entity platforms
 
 ## Installation
@@ -103,6 +105,63 @@ Each configured endpoint creates a device with the following entities:
   - `truncated`: Boolean indicating if response was truncated due to size limit
 
 *Note: Home Assistant automatically tracks when sensor states change via `last_changed` and `last_updated` attributes.*
+
+## Triggers
+
+*Requires Home Assistant 2026.7 or later.*
+
+HAAPI provides integration-specific triggers so automations can react the moment a call completes — without pressing a button, adding a `delay`, and then watching the response sensor. Watching `sensor.{endpoint}_response` with a generic state trigger is unreliable, because that sensor's state is the HTTP status code: two calls that both return `200` produce no state change, so the automation never fires. The triggers below fire on the actual call completion instead.
+
+| Trigger | Fires when |
+| --- | --- |
+| **Response received** | A call completes, for any result. Optional **Status code** field limits it to one status (e.g. `429`). |
+| **Call succeeded** | A call completes with a `2xx` status. |
+| **Call failed** | A call fails: a network/timeout error (status `0`) or an HTTP error (status `400`+). |
+| **Response changed** | The response body differs from the previous call to that endpoint. |
+| **Status code changed** | The HTTP status code differs from the previous call to that endpoint. |
+
+Each trigger can target one or more endpoint devices, or be left untargeted to fire for every endpoint.
+
+**Trigger variables** — every trigger exposes the result under `trigger`:
+
+| Variable | Description |
+| --- | --- |
+| `trigger.endpoint_name` | The endpoint's name |
+| `trigger.endpoint_id` | The endpoint's internal ID |
+| `trigger.status` | HTTP status code (`0` = network/timeout error) |
+| `trigger.ok` | `true` for a `2xx` status |
+| `trigger.body` | Response body (truncated per the endpoint's max response size) |
+| `trigger.headers` | Response headers as a dictionary |
+| `trigger.truncated` | Whether the body was truncated |
+| `trigger.status_changed` | Whether the status changed vs. the previous call |
+| `trigger.body_changed` | Whether the body changed vs. the previous call |
+| `trigger.previous_status` | The previous call's status code (`null` on the first call) |
+
+**Example** — notify only when an endpoint's response actually changes:
+```yaml
+automation:
+  - alias: "Notify when API result changes"
+    triggers:
+      - trigger: haapi.response_changed
+        target:
+          device_id: <your HAAPI endpoint device>
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "API changed: {{ trigger.body }}"
+```
+
+**Example** — alert on a failed call:
+```yaml
+automation:
+  - alias: "Alert on API failure"
+    triggers:
+      - trigger: haapi.call_failed
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "{{ trigger.endpoint_name }} failed (status {{ trigger.status }})"
+```
 
 ## Usage
 

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -50,6 +50,18 @@ from .const import (
     DEFAULT_MAX_RESPONSE_SIZE,
     DEFAULT_RETRIES,
     DEFAULT_RETRY_DELAY,
+    EVENT_HAAPI_RESPONSE,
+    ATTR_ENTRY_ID,
+    ATTR_ENDPOINT_ID,
+    ATTR_ENDPOINT_NAME,
+    ATTR_STATUS,
+    ATTR_OK,
+    ATTR_BODY,
+    ATTR_HEADERS,
+    ATTR_TRUNCATED,
+    ATTR_STATUS_CHANGED,
+    ATTR_BODY_CHANGED,
+    ATTR_PREVIOUS_STATUS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,7 +124,9 @@ class HaapiCoordinator:
         for endpoint_config in endpoints:
             endpoint_id = endpoint_config[CONF_ENDPOINT_ID]
             endpoint_data = stored_data.get(endpoint_id, {})
-            api_caller = HaapiApiCaller(hass, endpoint_config, endpoint_data, self._save_data)
+            api_caller = HaapiApiCaller(
+                hass, entry.entry_id, endpoint_config, endpoint_data, self._save_data
+            )
             self._api_callers[endpoint_id] = api_caller
 
     def get_api_caller(self, endpoint_id: str) -> HaapiApiCaller | None:
@@ -143,12 +157,14 @@ class HaapiApiCaller:
     def __init__(
         self,
         hass: HomeAssistant,
+        entry_id: str,
         endpoint_config: dict[str, Any],
         stored_data: dict[str, Any],
         save_callback,
     ) -> None:
         """Initialize the API caller."""
         self.hass = hass
+        self._entry_id = entry_id
         self.endpoint_config = endpoint_config
         self._save_callback = save_callback
 
@@ -263,6 +279,10 @@ class HaapiApiCaller:
 
     async def async_call_api(self) -> None:
         """Execute the API call."""
+        # Capture the prior result so we can report what changed after the call.
+        prev_code = self._last_response_code
+        prev_body = self._last_response_body
+
         url = self._render_template(self.endpoint_config[CONF_URL])
         method = self.endpoint_config[CONF_METHOD]
         headers = self._parse_headers(self.endpoint_config.get(CONF_HEADERS, ""))
@@ -436,3 +456,28 @@ class HaapiApiCaller:
 
         # Notify all entities of the update
         self._notify_listeners()
+
+        # Fire the completion event so integration-specific triggers can react.
+        self._fire_response_event(prev_code, prev_body)
+
+    def _fire_response_event(
+        self, prev_code: int | None, prev_body: str | None
+    ) -> None:
+        """Fire the haapi_response event describing the completed call."""
+        status = self._last_response_code or 0
+        self.hass.bus.async_fire(
+            EVENT_HAAPI_RESPONSE,
+            {
+                ATTR_ENTRY_ID: self._entry_id,
+                ATTR_ENDPOINT_ID: self.endpoint_id,
+                ATTR_ENDPOINT_NAME: self.endpoint_name,
+                ATTR_STATUS: status,
+                ATTR_OK: 200 <= status < 300,
+                ATTR_BODY: self._last_response_body,
+                ATTR_HEADERS: self._last_response_headers or {},
+                ATTR_TRUNCATED: self._truncated,
+                ATTR_STATUS_CHANGED: self._last_response_code != prev_code,
+                ATTR_BODY_CHANGED: self._last_response_body != prev_body,
+                ATTR_PREVIOUS_STATUS: prev_code,
+            },
+        )

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -125,7 +125,7 @@ class HaapiCoordinator:
             endpoint_id = endpoint_config[CONF_ENDPOINT_ID]
             endpoint_data = stored_data.get(endpoint_id, {})
             api_caller = HaapiApiCaller(
-                hass, entry.entry_id, endpoint_config, endpoint_data, self._save_data
+                hass, endpoint_config, endpoint_data, self._save_data, entry_id=entry.entry_id
             )
             self._api_callers[endpoint_id] = api_caller
 
@@ -157,10 +157,10 @@ class HaapiApiCaller:
     def __init__(
         self,
         hass: HomeAssistant,
-        entry_id: str,
         endpoint_config: dict[str, Any],
         stored_data: dict[str, Any],
         save_callback,
+        entry_id: str | None = None,
     ) -> None:
         """Initialize the API caller."""
         self.hass = hass

--- a/custom_components/haapi/const.py
+++ b/custom_components/haapi/const.py
@@ -48,6 +48,25 @@ DEFAULT_RETRY_DELAY = 1  # 1 second between retries
 SENSOR_REQUEST = "request"
 SENSOR_RESPONSE = "response"
 
+# Event fired on the bus whenever an endpoint completes a call. The trigger
+# platform listens for this; the payload doubles as the trigger variables.
+EVENT_HAAPI_RESPONSE = "haapi_response"
+
+# Trigger option keys
+CONF_STATUS = "status"
+
+# Event data keys (also exposed to automations as trigger variables)
+ATTR_ENTRY_ID = "entry_id"
+ATTR_ENDPOINT_ID = "endpoint_id"
+ATTR_ENDPOINT_NAME = "endpoint_name"
+ATTR_STATUS = "status"
+ATTR_OK = "ok"
+ATTR_BODY = "body"
+ATTR_HEADERS = "headers"
+ATTR_STATUS_CHANGED = "status_changed"
+ATTR_BODY_CHANGED = "body_changed"
+ATTR_PREVIOUS_STATUS = "previous_status"
+
 # Attributes
 ATTR_RESPONSE_BODY = "response_body"
 ATTR_RESPONSE_HEADERS = "response_headers"

--- a/custom_components/haapi/manifest.json
+++ b/custom_components/haapi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nasawa/HAAPI/issues",
   "requirements": [],
-  "version": "2.6.0"
+  "version": "2.7.0"
 }

--- a/custom_components/haapi/strings.json
+++ b/custom_components/haapi/strings.json
@@ -145,5 +145,33 @@
     "abort": {
       "no_endpoints": "No endpoints configured yet. Add an endpoint first."
     }
+  },
+  "triggers": {
+    "response_received": {
+      "name": "Response received",
+      "description": "Triggers when an endpoint completes a call, regardless of the result.",
+      "fields": {
+        "status": {
+          "name": "Status code",
+          "description": "Only trigger when the HTTP status code matches this value (0 means a network or timeout error). Leave empty to trigger on any status."
+        }
+      }
+    },
+    "call_succeeded": {
+      "name": "Call succeeded",
+      "description": "Triggers when an endpoint completes with a 2xx status code."
+    },
+    "call_failed": {
+      "name": "Call failed",
+      "description": "Triggers when a call fails: a network/timeout error (status 0) or an HTTP error (status 400 or higher)."
+    },
+    "response_changed": {
+      "name": "Response changed",
+      "description": "Triggers when the response body differs from the previous call to the endpoint."
+    },
+    "status_changed": {
+      "name": "Status code changed",
+      "description": "Triggers when the HTTP status code differs from the previous call to the endpoint."
+    }
   }
 }

--- a/custom_components/haapi/translations/en.json
+++ b/custom_components/haapi/translations/en.json
@@ -145,5 +145,33 @@
     "abort": {
       "no_endpoints": "No endpoints configured yet. Add an endpoint first."
     }
+  },
+  "triggers": {
+    "response_received": {
+      "name": "Response received",
+      "description": "Triggers when an endpoint completes a call, regardless of the result.",
+      "fields": {
+        "status": {
+          "name": "Status code",
+          "description": "Only trigger when the HTTP status code matches this value (0 means a network or timeout error). Leave empty to trigger on any status."
+        }
+      }
+    },
+    "call_succeeded": {
+      "name": "Call succeeded",
+      "description": "Triggers when an endpoint completes with a 2xx status code."
+    },
+    "call_failed": {
+      "name": "Call failed",
+      "description": "Triggers when a call fails: a network/timeout error (status 0) or an HTTP error (status 400 or higher)."
+    },
+    "response_changed": {
+      "name": "Response changed",
+      "description": "Triggers when the response body differs from the previous call to the endpoint."
+    },
+    "status_changed": {
+      "name": "Status code changed",
+      "description": "Triggers when the HTTP status code differs from the previous call to the endpoint."
+    }
   }
 }

--- a/custom_components/haapi/trigger.py
+++ b/custom_components/haapi/trigger.py
@@ -1,0 +1,204 @@
+"""Trigger platform for the HAAPI integration.
+
+Exposes integration-specific triggers (Home Assistant 2026.7+) so automations
+can react to an endpoint completing a call without watching the response sensor
+with a generic state trigger -- which silently misses repeats when the status
+code does not change. Each trigger listens for the ``haapi_response`` event the
+integration fires on every completed call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS, CONF_TARGET
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.target import (
+    TargetSelection,
+    async_extract_referenced_entity_ids,
+)
+from homeassistant.helpers.trigger import (
+    Trigger,
+    TriggerActionRunner,
+    TriggerConfig,
+    TriggerNotTriggeredReporter,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    ATTR_BODY_CHANGED,
+    ATTR_ENDPOINT_ID,
+    ATTR_ENDPOINT_NAME,
+    ATTR_ENTRY_ID,
+    ATTR_OK,
+    ATTR_STATUS,
+    ATTR_STATUS_CHANGED,
+    CONF_STATUS,
+    DOMAIN,
+    EVENT_HAAPI_RESPONSE,
+)
+
+_BASE_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS, default={}): {},
+    }
+)
+
+_RESPONSE_RECEIVED_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS, default={}): {
+            vol.Optional(CONF_STATUS): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=599)
+            ),
+        },
+    }
+)
+
+
+class HaapiTrigger(Trigger):
+    """Base class for HAAPI response triggers.
+
+    Subclasses define ``_event_matches`` to decide which completed calls fire.
+    An optional target restricts the trigger to specific endpoint devices; with
+    no target it fires for every endpoint.
+    """
+
+    _schema: vol.Schema = _BASE_TRIGGER_SCHEMA
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return cls._schema(config)
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        self._key = config.key
+        self._target = config.target
+        self._options = config.options or {}
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        """Return whether a completed call should fire this trigger."""
+        return True
+
+    @callback
+    def _resolve_target_idents(self) -> set[str] | None:
+        """Resolve the configured target to HAAPI device identifiers.
+
+        Returns a set of ``"<entry_id>_<endpoint_id>"`` identifier strings, or
+        ``None`` when no target is set (fire for every endpoint).
+        """
+        if not self._target:
+            return None
+        selection = TargetSelection(self._target)
+        if not selection.has_any_target:
+            return None
+
+        selected = async_extract_referenced_entity_ids(self._hass, selection)
+        ent_reg = er.async_get(self._hass)
+        dev_reg = dr.async_get(self._hass)
+
+        device_ids: set[str] = set(selected.referenced_devices)
+        for entity_id in selected.referenced | selected.indirectly_referenced:
+            entry = ent_reg.async_get(entity_id)
+            if entry and entry.device_id:
+                device_ids.add(entry.device_id)
+
+        idents: set[str] = set()
+        for device_id in device_ids:
+            device = dev_reg.async_get(device_id)
+            if not device:
+                continue
+            for domain, identifier in device.identifiers:
+                if domain == DOMAIN:
+                    idents.add(identifier)
+        return idents or None
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to its action runner."""
+        allowed = self._resolve_target_idents()
+
+        @callback
+        def _handle_event(event: Event) -> None:
+            data = event.data
+            if allowed is not None:
+                ident = f"{data[ATTR_ENTRY_ID]}_{data[ATTR_ENDPOINT_ID]}"
+                if ident not in allowed:
+                    return
+            if not self._event_matches(data):
+                return
+            payload: dict[str, Any] = {"platform": self._key, **data}
+            run_action(payload, f"{data[ATTR_ENDPOINT_NAME]} {self._key}", event.context)
+
+        return self._hass.bus.async_listen(EVENT_HAAPI_RESPONSE, _handle_event)
+
+
+class ResponseReceivedTrigger(HaapiTrigger):
+    """Fire whenever an endpoint completes a call (any status)."""
+
+    _schema = _RESPONSE_RECEIVED_SCHEMA
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        status = self._options.get(CONF_STATUS)
+        return status is None or data[ATTR_STATUS] == status
+
+
+class CallSucceededTrigger(HaapiTrigger):
+    """Fire when an endpoint completes with a 2xx status."""
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        return bool(data[ATTR_OK])
+
+
+class CallFailedTrigger(HaapiTrigger):
+    """Fire when a call fails: network/timeout error (status 0) or HTTP >= 400."""
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        status = data[ATTR_STATUS]
+        return status == 0 or status >= 400
+
+
+class ResponseChangedTrigger(HaapiTrigger):
+    """Fire when the response body differs from the previous call."""
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        return bool(data[ATTR_BODY_CHANGED])
+
+
+class StatusChangedTrigger(HaapiTrigger):
+    """Fire when the HTTP status code differs from the previous call."""
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        return bool(data[ATTR_STATUS_CHANGED])
+
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    "response_received": ResponseReceivedTrigger,
+    "call_succeeded": CallSucceededTrigger,
+    "call_failed": CallFailedTrigger,
+    "response_changed": ResponseChangedTrigger,
+    "status_changed": StatusChangedTrigger,
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return the triggers provided by HAAPI."""
+    return TRIGGERS

--- a/custom_components/haapi/trigger.py
+++ b/custom_components/haapi/trigger.py
@@ -9,7 +9,7 @@ integration fires on every completed call.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -21,13 +21,15 @@ from homeassistant.helpers.target import (
     TargetSelection,
     async_extract_referenced_entity_ids,
 )
-from homeassistant.helpers.trigger import (
-    Trigger,
-    TriggerActionRunner,
-    TriggerConfig,
-    TriggerNotTriggeredReporter,
-)
+from homeassistant.helpers.trigger import Trigger
 from homeassistant.helpers.typing import ConfigType
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
 
 from .const import (
     ATTR_BODY_CHANGED,
@@ -40,6 +42,20 @@ from .const import (
     CONF_STATUS,
     DOMAIN,
     EVENT_HAAPI_RESPONSE,
+)
+
+# Keys every subclass reads off the event payload; used to drop malformed
+# haapi_response events fired by foreign automations on the global bus.
+_REQUIRED_EVENT_KEYS = frozenset(
+    {
+        ATTR_ENTRY_ID,
+        ATTR_ENDPOINT_ID,
+        ATTR_ENDPOINT_NAME,
+        ATTR_STATUS,
+        ATTR_OK,
+        ATTR_STATUS_CHANGED,
+        ATTR_BODY_CHANGED,
+    }
 )
 
 _BASE_TRIGGER_SCHEMA = vol.Schema(
@@ -134,6 +150,11 @@ class HaapiTrigger(Trigger):
         @callback
         def _handle_event(event: Event) -> None:
             data = event.data
+            # The event bus is global, so a foreign automation could fire a
+            # malformed haapi_response. Ignore anything missing required fields
+            # instead of raising KeyError / spamming the log.
+            if not _REQUIRED_EVENT_KEYS <= data.keys():
+                return
             if allowed is not None:
                 ident = f"{data[ATTR_ENTRY_ID]}_{data[ATTR_ENDPOINT_ID]}"
                 if ident not in allowed:

--- a/custom_components/haapi/triggers.yaml
+++ b/custom_components/haapi/triggers.yaml
@@ -1,0 +1,26 @@
+.endpoint_target: &endpoint_target
+  target:
+    device:
+      integration: haapi
+
+response_received:
+  target:
+    device:
+      integration: haapi
+  fields:
+    status:
+      required: false
+      example: 429
+      selector:
+        number:
+          min: 0
+          max: 599
+          mode: box
+
+call_succeeded: *endpoint_target
+
+call_failed: *endpoint_target
+
+response_changed: *endpoint_target
+
+status_changed: *endpoint_target

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 """Test the HAAPI __init__ module."""
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiohttp
 import pytest
@@ -323,3 +323,126 @@ async def test_api_call_with_invalid_json_body(hass: HomeAssistant, mock_endpoin
     assert "data" in call_kwargs
     assert call_kwargs["data"] == "not valid json"
     assert call_kwargs.get("json") is None
+
+
+# ---------------------------------------------------------------------------
+# haapi_response event + change detection (integration triggers, 2.7.0)
+# ---------------------------------------------------------------------------
+
+from homeassistant.core import HomeAssistant as _HA  # noqa: E402
+from pytest_homeassistant_custom_component.common import async_capture_events  # noqa: E402
+
+from custom_components.haapi.const import (  # noqa: E402
+    ATTR_BODY,
+    ATTR_BODY_CHANGED,
+    ATTR_ENDPOINT_ID,
+    ATTR_ENDPOINT_NAME,
+    ATTR_ENTRY_ID,
+    ATTR_OK,
+    ATTR_PREVIOUS_STATUS,
+    ATTR_STATUS,
+    ATTR_STATUS_CHANGED,
+    EVENT_HAAPI_RESPONSE,
+)
+
+
+def _mock_client_session(status, body, headers=None):
+    """Build an aiohttp.ClientSession mock that behaves as an async CM."""
+    response = AsyncMock()
+    response.status = status
+    response.text = AsyncMock(return_value=body)
+    response.headers = headers or {}
+
+    req_cm = MagicMock()
+    req_cm.__aenter__ = AsyncMock(return_value=response)
+    req_cm.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock()
+    session.request = MagicMock(return_value=req_cm)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    return session
+
+
+async def test_response_event_fired(hass: HomeAssistant, mock_endpoint_config) -> None:
+    """A completed call fires haapi_response with the expected payload."""
+    from custom_components.haapi import HaapiApiCaller
+
+    events = async_capture_events(hass, EVENT_HAAPI_RESPONSE)
+    api_caller = HaapiApiCaller(
+        hass, mock_endpoint_config, {}, AsyncMock(), entry_id="entry-1"
+    )
+
+    session = _mock_client_session(200, "hello", {"Content-Type": "text/plain"})
+    with patch("aiohttp.ClientSession", return_value=session):
+        await api_caller.async_call_api()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    data = events[0].data
+    assert data[ATTR_ENTRY_ID] == "entry-1"
+    assert data[ATTR_ENDPOINT_ID] == "test-endpoint-id"
+    assert data[ATTR_ENDPOINT_NAME] == "Test Endpoint"
+    assert data[ATTR_STATUS] == 200
+    assert data[ATTR_OK] is True
+    assert data[ATTR_BODY] == "hello"
+    # First-ever call: no prior values, so both register as changed.
+    assert data[ATTR_STATUS_CHANGED] is True
+    assert data[ATTR_BODY_CHANGED] is True
+    assert data[ATTR_PREVIOUS_STATUS] is None
+
+
+async def test_change_detection_across_calls(
+    hass: HomeAssistant, mock_endpoint_config
+) -> None:
+    """status_changed / body_changed reflect diffs vs. the previous call."""
+    from custom_components.haapi import HaapiApiCaller
+
+    events = async_capture_events(hass, EVENT_HAAPI_RESPONSE)
+    api_caller = HaapiApiCaller(
+        hass, mock_endpoint_config, {}, AsyncMock(), entry_id="entry-1"
+    )
+
+    async def _call(status, body):
+        with patch(
+            "aiohttp.ClientSession",
+            return_value=_mock_client_session(status, body),
+        ):
+            await api_caller.async_call_api()
+        await hass.async_block_till_done()
+
+    await _call(200, "A")  # first
+    await _call(200, "A")  # identical
+    await _call(200, "B")  # body changed only
+    await _call(500, "B")  # status changed only
+
+    assert [e.data[ATTR_STATUS_CHANGED] for e in events] == [True, False, False, True]
+    assert [e.data[ATTR_BODY_CHANGED] for e in events] == [True, False, True, False]
+    assert [e.data[ATTR_OK] for e in events] == [True, True, True, False]
+    assert events[3].data[ATTR_PREVIOUS_STATUS] == 200
+
+
+async def test_failed_call_fires_event(hass: HomeAssistant, mock_endpoint_config) -> None:
+    """A network error still fires the event with status 0 / ok False."""
+    from custom_components.haapi import HaapiApiCaller
+
+    events = async_capture_events(hass, EVENT_HAAPI_RESPONSE)
+    api_caller = HaapiApiCaller(
+        hass, mock_endpoint_config, {}, AsyncMock(), entry_id="entry-1"
+    )
+
+    req_cm = MagicMock()
+    req_cm.__aenter__ = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+    req_cm.__aexit__ = AsyncMock(return_value=None)
+    session = MagicMock()
+    session.request = MagicMock(return_value=req_cm)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("aiohttp.ClientSession", return_value=session):
+        await api_caller.async_call_api()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data[ATTR_STATUS] == 0
+    assert events[0].data[ATTR_OK] is False

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,0 +1,138 @@
+"""Tests for the HAAPI trigger platform."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.trigger import TriggerConfig
+
+from custom_components.haapi import trigger as trig
+from custom_components.haapi.const import (
+    ATTR_BODY,
+    ATTR_BODY_CHANGED,
+    ATTR_ENDPOINT_ID,
+    ATTR_ENDPOINT_NAME,
+    ATTR_ENTRY_ID,
+    ATTR_HEADERS,
+    ATTR_OK,
+    ATTR_PREVIOUS_STATUS,
+    ATTR_STATUS,
+    ATTR_STATUS_CHANGED,
+    ATTR_TRUNCATED,
+    EVENT_HAAPI_RESPONSE,
+)
+
+
+def _data(**over):
+    """Build a well-formed haapi_response payload, overridable per-key."""
+    base = {
+        ATTR_ENTRY_ID: "entry-1",
+        ATTR_ENDPOINT_ID: "ep-1",
+        ATTR_ENDPOINT_NAME: "Test Endpoint",
+        ATTR_STATUS: 200,
+        ATTR_OK: True,
+        ATTR_BODY: "x",
+        ATTR_HEADERS: {},
+        ATTR_TRUNCATED: False,
+        ATTR_STATUS_CHANGED: True,
+        ATTR_BODY_CHANGED: True,
+        ATTR_PREVIOUS_STATUS: None,
+    }
+    base.update(over)
+    return base
+
+
+def _make(cls, options=None, target=None, hass=None):
+    return cls(hass, TriggerConfig(key=f"haapi.{cls.__name__}", target=target, options=options or {}))
+
+
+async def test_get_triggers(hass: HomeAssistant) -> None:
+    """All five triggers are exposed."""
+    triggers = await trig.async_get_triggers(hass)
+    assert set(triggers) == {
+        "response_received",
+        "call_succeeded",
+        "call_failed",
+        "response_changed",
+        "status_changed",
+    }
+
+
+def test_event_matches_response_received() -> None:
+    t = _make(trig.ResponseReceivedTrigger)
+    assert t._event_matches(_data(status=200)) is True
+    assert t._event_matches(_data(status=500)) is True
+    # status filter
+    t_filtered = _make(trig.ResponseReceivedTrigger, options={"status": 429})
+    assert t_filtered._event_matches(_data(status=429)) is True
+    assert t_filtered._event_matches(_data(status=200)) is False
+
+
+def test_event_matches_succeeded_failed() -> None:
+    ok = _make(trig.CallSucceededTrigger)
+    assert ok._event_matches(_data(ok=True)) is True
+    assert ok._event_matches(_data(ok=False)) is False
+
+    fail = _make(trig.CallFailedTrigger)
+    assert fail._event_matches(_data(status=0)) is True      # network error
+    assert fail._event_matches(_data(status=404)) is True    # HTTP error
+    assert fail._event_matches(_data(status=200)) is False
+
+
+def test_event_matches_changed() -> None:
+    body = _make(trig.ResponseChangedTrigger)
+    assert body._event_matches(_data(body_changed=True)) is True
+    assert body._event_matches(_data(body_changed=False)) is False
+
+    status = _make(trig.StatusChangedTrigger)
+    assert status._event_matches(_data(status_changed=True)) is True
+    assert status._event_matches(_data(status_changed=False)) is False
+
+
+async def test_validate_config(hass: HomeAssistant) -> None:
+    cfg = await trig.ResponseReceivedTrigger.async_validate_config(
+        hass, {"options": {"status": 429}}
+    )
+    assert cfg["options"]["status"] == 429
+    cfg2 = await trig.CallFailedTrigger.async_validate_config(hass, {})
+    assert cfg2["options"] == {}
+
+
+async def test_attach_runner_fires_filters_and_unsubscribes(hass: HomeAssistant) -> None:
+    """async_attach_runner fires on match, drops malformed events, unsubscribes."""
+    calls: list[dict] = []
+
+    def run_action(payload, description, context=None):
+        calls.append(payload)
+
+    t = _make(trig.ResponseReceivedTrigger, hass=hass)
+    unsub = await t.async_attach_runner(run_action)
+
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, _data())
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0]["platform"] == "haapi.ResponseReceivedTrigger"
+    assert calls[0][ATTR_ENDPOINT_NAME] == "Test Endpoint"
+
+    # Malformed event (missing required keys) is ignored, no KeyError.
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, {ATTR_ENDPOINT_NAME: "x"})
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    unsub()
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, _data())
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_attach_runner_status_filter(hass: HomeAssistant) -> None:
+    calls: list[dict] = []
+    t = _make(trig.ResponseReceivedTrigger, options={"status": 429}, hass=hass)
+    unsub = await t.async_attach_runner(lambda p, d, c=None: calls.append(p))
+
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, _data(status=200))
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, _data(status=429))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0][ATTR_STATUS] == 429
+    unsub()


### PR DESCRIPTION
## What

Adds integration-specific triggers (Home Assistant 2026.7+) to HAAPI so automations can react the instant an endpoint call completes — no more *press button → `delay` → watch the response sensor* dance.

### Why
Watching `sensor.{endpoint}_response` with a generic state trigger is unreliable: that sensor's state is the HTTP status code, so two calls that both return `200` produce no state change and the automation never fires. 2026.7 lets integrations register their own triggers, which is the right fix.

### Triggers (each targetable to specific endpoint devices, or untargeted = all)
| Trigger | Fires when |
| --- | --- |
| `haapi.response_received` | A call completes (any status). Optional `status` field filters to one code (e.g. 429). |
| `haapi.call_succeeded` | Completes with a 2xx. |
| `haapi.call_failed` | Network/timeout error (status 0) or HTTP ≥ 400. |
| `haapi.response_changed` | Response body differs from the previous call. |
| `haapi.status_changed` | Status code differs from the previous call. |

Every trigger exposes the result as trigger variables: `endpoint_name`, `endpoint_id`, `status`, `ok`, `body`, `headers`, `truncated`, `status_changed`, `body_changed`, `previous_status`.

## How
- `async_call_api` fires a `haapi_response` bus event on **every** completion (success, HTTP error, and network/timeout error) carrying the result + status/body change diffs (computed against the prior stored values).
- `trigger.py` implements the new class-based trigger platform (`TRIGGERS` + `async_get_triggers`); `triggers.yaml` describes them for the UI; `strings.json` + `translations/en.json` add names/descriptions.
- Endpoint targeting resolves the trigger's target (device/entity/area/…) to HAAPI device identifiers via `helpers.target`.

## Compatibility
- No breaking changes to existing `button`/`sensor` entities.
- Triggers require HA 2026.7+ (the new trigger framework). Version bumped 2.6.0 → 2.7.0.

## Testing
- Static: `py_compile` clean; `manifest.json` / `strings.json` / `en.json` valid JSON; `triggers.yaml` parses and anchors expand.
- ⚠️ Not yet load-tested in a running HA instance — review + a live smoke test on 2026.7 recommended before merge.