### PR TITLE
Modernize the test suite (fix legacy-failing tests)

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,12 +39,33 @@ def make_session(*responses, raise_exc=None):
     session = MagicMock()
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=None)
+
     if raise_exc is not None:
         session.request = MagicMock(side_effect=raise_exc)
-    elif len(responses) == 1:
+        return session
+
+    if not responses:
+        raise ValueError("make_session requires at least one response or raise_exc=")
+
+    if len(responses) == 1:
+        # Single response: request() can be called any number of times.
         session.request = MagicMock(return_value=_request_cm(responses[0]))
-    else:
-        session.request = MagicMock(side_effect=[_request_cm(r) for r in responses])
+        return session
+
+    # Multiple responses: return each in turn, with a clear error if the code
+    # under test calls request() more times than responses were provided
+    # (instead of a confusing StopIteration).
+    cms = [_request_cm(r) for r in responses]
+
+    def _next_cm(*_args, **_kwargs):
+        if not cms:
+            raise AssertionError(
+                f"make_session: request() called more than the {len(responses)} "
+                "responses provided"
+            )
+        return cms.pop(0)
+
+    session.request = MagicMock(side_effect=_next_cm)
     return session
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,53 @@
+"""Shared test helpers for HAAPI.
+
+The integration calls ``async with session.request(...) as response:``. A bare
+``AsyncMock`` whose ``request`` returns the response does NOT form a valid async
+context manager (the call returns a coroutine, not a CM), so the request path
+raises and the caller records a status 0. These helpers build a session mock
+whose ``request`` returns a proper async context manager.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+
+def make_response(status, body, headers=None):
+    """Build a mock aiohttp response with the given status/body/headers."""
+    response = AsyncMock()
+    response.status = status
+    response.text = AsyncMock(return_value=body)
+    response.headers = headers or {}
+    return response
+
+
+def _request_cm(response):
+    """Wrap a response in an async context manager (what request() returns)."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def make_session(*responses, raise_exc=None):
+    """Build a mock aiohttp.ClientSession usable as an async context manager.
+
+    - ``make_session(resp)`` -> request() always returns ``resp``.
+    - ``make_session(r1, r2, r3)`` -> request() returns each in turn (retries).
+    - ``make_session(raise_exc=exc)`` -> request() raises ``exc`` on every call.
+    """
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    if raise_exc is not None:
+        session.request = MagicMock(side_effect=raise_exc)
+    elif len(responses) == 1:
+        session.request = MagicMock(return_value=_request_cm(responses[0]))
+    else:
+        session.request = MagicMock(side_effect=[_request_cm(r) for r in responses])
+    return session
+
+
+def mock_client_session(status, body, headers=None):
+    """Convenience: a session whose single response has the given status/body."""
+    return make_session(make_response(status, body, headers))

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -15,6 +15,7 @@ async def test_button_press(hass: HomeAssistant, mock_config_entry_data, mock_co
         domain=DOMAIN,
         data=mock_config_entry_data,
         options=mock_config_entry_options,
+        version=2,
     )
     entry.add_to_hass(hass)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -41,7 +41,8 @@ async def test_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
+    # HA returns errors: None on a clean initial form (older versions used {}).
+    assert result["errors"] in (None, {})
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haapi import async_setup_entry, async_unload_entry
 from custom_components.haapi.const import DOMAIN
 
 
@@ -18,17 +17,21 @@ async def test_setup_unload_entry(hass: HomeAssistant, mock_config_entry_data, m
         domain=DOMAIN,
         data=mock_config_entry_data,
         options=mock_config_entry_options,
+        version=2,
     )
     entry.add_to_hass(hass)
 
+    # Go through the config-entries state machine; modern HA requires the entry
+    # to be LOADED before platforms can be forwarded (a direct async_setup_entry
+    # call leaves it NOT_LOADED).
     with patch("custom_components.haapi.Store.async_load", return_value={}):
-        assert await async_setup_entry(hass, entry)
+        assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     assert DOMAIN in hass.data
     assert entry.entry_id in hass.data[DOMAIN]
 
-    assert await async_unload_entry(hass, entry)
+    assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     assert entry.entry_id not in hass.data[DOMAIN]
@@ -58,10 +61,7 @@ async def test_api_call_success(
     mock_response.text = AsyncMock(return_value=response_text)
     mock_response.headers = {"Content-Type": "text/plain"}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -87,10 +87,7 @@ async def test_api_call_with_truncation(hass: HomeAssistant, mock_endpoint_confi
     mock_response.text = AsyncMock(return_value=large_response)
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -123,12 +120,9 @@ async def test_api_call_with_retries(hass: HomeAssistant, mock_endpoint_config) 
     mock_response_success.text = AsyncMock(return_value="Success")
     mock_response_success.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(
-        side_effect=[mock_response_fail, mock_response_fail, mock_response_success]
+    mock_session = make_session(
+        mock_response_fail, mock_response_fail, mock_response_success
     )
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -152,10 +146,7 @@ async def test_api_call_retry_exhausted(hass: HomeAssistant, mock_endpoint_confi
     mock_endpoint_config["retry_delay"] = 0
 
     # All calls fail with network error
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(side_effect=aiohttp.ClientError("Connection failed"))
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(raise_exc=aiohttp.ClientError("Connection failed"))
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -183,10 +174,7 @@ async def test_api_call_no_retry_on_client_error(hass: HomeAssistant, mock_endpo
     mock_response.text = AsyncMock(return_value="Not Found")
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -210,10 +198,7 @@ async def test_api_call_with_ssl_disabled(hass: HomeAssistant, mock_endpoint_con
     mock_response.text = AsyncMock(return_value="Success")
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -240,10 +225,7 @@ async def test_api_call_with_json_body(hass: HomeAssistant, mock_endpoint_config
     mock_response.text = AsyncMock(return_value="Success")
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -273,10 +255,7 @@ async def test_api_call_with_form_data(hass: HomeAssistant, mock_endpoint_config
     mock_response.text = AsyncMock(return_value="Success")
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -306,10 +285,7 @@ async def test_api_call_with_invalid_json_body(hass: HomeAssistant, mock_endpoin
     mock_response.text = AsyncMock(return_value="Success")
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     save_callback = AsyncMock()
     api_caller = HaapiApiCaller(hass, mock_endpoint_config, {}, save_callback)
@@ -329,7 +305,6 @@ async def test_api_call_with_invalid_json_body(hass: HomeAssistant, mock_endpoin
 # haapi_response event + change detection (integration triggers, 2.7.0)
 # ---------------------------------------------------------------------------
 
-from homeassistant.core import HomeAssistant as _HA  # noqa: E402
 from pytest_homeassistant_custom_component.common import async_capture_events  # noqa: E402
 
 from custom_components.haapi.const import (  # noqa: E402
@@ -346,22 +321,8 @@ from custom_components.haapi.const import (  # noqa: E402
 )
 
 
-def _mock_client_session(status, body, headers=None):
-    """Build an aiohttp.ClientSession mock that behaves as an async CM."""
-    response = AsyncMock()
-    response.status = status
-    response.text = AsyncMock(return_value=body)
-    response.headers = headers or {}
-
-    req_cm = MagicMock()
-    req_cm.__aenter__ = AsyncMock(return_value=response)
-    req_cm.__aexit__ = AsyncMock(return_value=None)
-
-    session = MagicMock()
-    session.request = MagicMock(return_value=req_cm)
-    session.__aenter__ = AsyncMock(return_value=session)
-    session.__aexit__ = AsyncMock(return_value=None)
-    return session
+from tests.helpers import make_session  # noqa: E402
+from tests.helpers import mock_client_session as _mock_client_session  # noqa: E402
 
 
 async def test_response_event_fired(hass: HomeAssistant, mock_endpoint_config) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,6 +6,8 @@ import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from tests.helpers import make_session
+
 from custom_components.haapi.const import (
     ATTR_MAX_RESPONSE_SIZE,
     ATTR_RETRIES,
@@ -24,6 +26,7 @@ async def test_request_sensor(hass: HomeAssistant, mock_config_entry_data, mock_
         domain=DOMAIN,
         data=mock_config_entry_data,
         options=mock_config_entry_options,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -54,6 +57,7 @@ async def test_response_sensor(hass: HomeAssistant, mock_config_entry_data, mock
         domain=DOMAIN,
         data=mock_config_entry_data,
         options=mock_config_entry_options,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -80,10 +84,7 @@ async def test_response_sensor(hass: HomeAssistant, mock_config_entry_data, mock
     mock_response.text = AsyncMock(return_value='{"result": "success"}')
     mock_response.headers = {"Content-Type": "application/json"}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     with patch("aiohttp.ClientSession", return_value=mock_session):
         await api_caller.async_call_api()
@@ -113,6 +114,7 @@ async def test_response_sensor_with_truncation(
         domain=DOMAIN,
         data=mock_config_entry_data,
         options=options,
+        version=2,
     )
     entry.add_to_hass(hass)
 
@@ -132,10 +134,7 @@ async def test_response_sensor_with_truncation(
     mock_response.text = AsyncMock(return_value=large_response)
     mock_response.headers = {}
 
-    mock_session = AsyncMock()
-    mock_session.request = AsyncMock(return_value=mock_response)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session = make_session(mock_response)
 
     with patch("aiohttp.ClientSession", return_value=mock_session):
         await api_caller.async_call_api()


### PR DESCRIPTION
## What
Fixes the pre-existing test failures so the suite runs green against a current Home Assistant test harness. **Tests only — no production code changed.** Result: **30 passed**.

## Root causes (all version-drift)
1. **Broken async-CM mock.** Tests set `session.request = AsyncMock(return_value=resp)`, but the integration does `async with session.request(...) as response:`. An `AsyncMock` call returns a coroutine, not an async context manager → the request path raised → caller recorded status `0` (`assert 0 == 200`). Added `tests/helpers.py` (`make_response` / `make_session` / `mock_client_session`) building a session whose `request()` returns a real async CM, and refactored `test_init.py` + `test_sensor.py` onto it (single response, retry sequences, and raised network errors).
2. **MockConfigEntry version.** Entries were created without `version=`, defaulting to 1 while the config flow is `VERSION = 2` → HA attempted migration, found no handler, aborted setup → no entities (`assert state is not None`). Added `version=2`.
3. **Config-flow form errors.** Modern HA returns `errors: None` (not `{}`) on a clean initial form; relaxed the assertion.
4. **Direct `async_setup_entry`.** `test_setup_unload_entry` now drives the config-entries state machine (`hass.config_entries.async_setup`/`async_unload`) instead of calling `async_setup_entry` directly, which modern HA rejects (entry must be `LOADED` before forwarding platforms).

## Verification
`pytest` → 30 passed (Python 3.13, pytest-homeassistant-custom-component / HA 2026.2.3). Uses the `pytest.ini` (`asyncio_mode = auto`) added in #12.

Follow-up (separate PR): add CI to run this suite automatically.