### PR TITLE
Add CI (pytest, hassfest, HACS validation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: these jobs only read the repo. HACS commenting is disabled
+# below so no pull-requests: write is needed.
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests
@@ -15,16 +20,19 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
+          cache-dependency-path: requirements_test.txt
       - name: Install test dependencies
-        run: pip install -r requirements_test.txt
+        run: python -m pip install -r requirements_test.txt
       - name: Run pytest
-        run: pytest -q
+        run: python -m pytest -q
 
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # home-assistant/actions/hassfest is the official validator; it is
+      # referenced at @master by design so it tracks current HA requirements.
       - uses: home-assistant/actions/hassfest@master
 
   hacs:
@@ -32,8 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # hacs/action is the official validator; referenced at @main by design so
+      # it tracks current HACS rules.
       - uses: hacs/action@main
         with:
           category: integration
           # This integration is not (and need not be) in home-assistant/brands.
           ignore: brands
+          comment: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run pytest
+        run: pytest -q
+
+  hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration
+          # This integration is not (and need not be) in home-assistant/brands.
+          ignore: brands


### PR DESCRIPTION
## What
Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) — the repo had none. Runs on every PR and on pushes to `main`:

- **Tests** — Python 3.13, `pip install -r requirements_test.txt`, `pytest` (the `pytest.ini` from #12 sets `asyncio_mode = auto`). Now that the suite is green (#13), this gates real regressions — exactly the trigger param/signature breakage and integration-load failures from the recent work.
- **Hassfest** — validates the integration manifest/structure.
- **HACS validation** — `category: integration`, with `ignore: brands` (this is a custom integration, intentionally not in `home-assistant/brands`).

## Notes
First CI run is on this PR itself — I'll confirm all three jobs go green before this is ready to merge.