### PR TITLE
Content, JSON-path, and health-edge triggers (2.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,15 @@ HAAPI provides integration-specific triggers so automations can react the moment
 | **Call failed** | A call fails: a network/timeout error (status `0`) or an HTTP error (status `400`+). |
 | **Response changed** | The response body differs from the previous call to that endpoint. |
 | **Status code changed** | The HTTP status code differs from the previous call to that endpoint. |
+| **Response body matches** | The response body matches a regular expression (`pattern`). |
+| **Response value matches** | A JSON field (`path`, e.g. `state` or `ams.0.humidity`) `equals` a value or matches a `pattern`. With neither, fires whenever the path resolves. |
+| **Response value changed** | A JSON field (`path`) differs from the previous call — field-level version of *Response changed*. |
+| **Recovered** | A call succeeds (2xx) after the previous call had failed. |
+| **Went down** | A call fails after the previous call had succeeded (2xx). |
 
 Each trigger can target one or more endpoint devices, or be left untargeted to fire for every endpoint.
+
+JSON field paths are dotted (`state`, `ams.0.humidity`), with list items addressed by index. This is a lightweight built-in resolver — no JSONPath dependency. If the body isn't JSON or the path doesn't resolve, value triggers simply don't fire.
 
 **Trigger variables** — every trigger exposes the result under `trigger`:
 
@@ -136,6 +143,7 @@ Each trigger can target one or more endpoint devices, or be left untargeted to f
 | `trigger.status_changed` | Whether the status changed vs. the previous call |
 | `trigger.body_changed` | Whether the body changed vs. the previous call |
 | `trigger.previous_status` | The previous call's status code (`null` on the first call) |
+| `trigger.previous_body` | The previous call's response body (`null` on the first call) |
 
 **Example** — notify only when an endpoint's response actually changes:
 ```yaml
@@ -161,6 +169,23 @@ automation:
       - action: notify.mobile_app
         data:
           message: "{{ trigger.endpoint_name }} failed (status {{ trigger.status }})"
+```
+
+**Example** — act only when a specific JSON field reaches a value:
+```yaml
+automation:
+  - alias: "Notify when print finishes"
+    trigger:
+      - trigger: haapi.value_matches
+        target:
+          device_id: <your HAAPI endpoint device>
+        options:
+          path: state
+          equals: FINISH
+    action:
+      - action: notify.mobile_app
+        data:
+          message: "Print finished"
 ```
 
 ## Usage

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -62,6 +62,7 @@ from .const import (
     ATTR_STATUS_CHANGED,
     ATTR_BODY_CHANGED,
     ATTR_PREVIOUS_STATUS,
+    ATTR_PREVIOUS_BODY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -479,5 +480,6 @@ class HaapiApiCaller:
                 ATTR_STATUS_CHANGED: self._last_response_code != prev_code,
                 ATTR_BODY_CHANGED: self._last_response_body != prev_body,
                 ATTR_PREVIOUS_STATUS: prev_code,
+                ATTR_PREVIOUS_BODY: prev_body,
             },
         )

--- a/custom_components/haapi/const.py
+++ b/custom_components/haapi/const.py
@@ -54,6 +54,9 @@ EVENT_HAAPI_RESPONSE = "haapi_response"
 
 # Trigger option keys
 CONF_STATUS = "status"
+CONF_PATTERN = "pattern"
+CONF_PATH = "path"
+CONF_EQUALS = "equals"
 
 # Event data keys (also exposed to automations as trigger variables)
 ATTR_ENTRY_ID = "entry_id"
@@ -66,6 +69,7 @@ ATTR_HEADERS = "headers"
 ATTR_STATUS_CHANGED = "status_changed"
 ATTR_BODY_CHANGED = "body_changed"
 ATTR_PREVIOUS_STATUS = "previous_status"
+ATTR_PREVIOUS_BODY = "previous_body"
 
 # Attributes
 ATTR_RESPONSE_BODY = "response_body"

--- a/custom_components/haapi/manifest.json
+++ b/custom_components/haapi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nasawa/HAAPI/issues",
   "requirements": [],
-  "version": "2.7.0"
+  "version": "2.8.0"
 }

--- a/custom_components/haapi/strings.json
+++ b/custom_components/haapi/strings.json
@@ -172,6 +172,52 @@
     "status_changed": {
       "name": "Status code changed",
       "description": "Triggers when the HTTP status code differs from the previous call to the endpoint."
+    },
+    "body_matches": {
+      "name": "Response body matches",
+      "description": "Triggers when the response body matches a regular expression.",
+      "fields": {
+        "pattern": {
+          "name": "Pattern",
+          "description": "Regular expression to search for anywhere in the response body."
+        }
+      }
+    },
+    "value_matches": {
+      "name": "Response value matches",
+      "description": "Triggers when a field in the JSON response body equals or matches a value.",
+      "fields": {
+        "path": {
+          "name": "Field path",
+          "description": "Dotted path to the field, e.g. 'state' or 'ams.0.humidity' (list items by index)."
+        },
+        "equals": {
+          "name": "Equals",
+          "description": "Trigger only when the field equals this value (string comparison). Leave empty to skip."
+        },
+        "pattern": {
+          "name": "Pattern",
+          "description": "Trigger only when the field matches this regular expression. Leave empty to skip."
+        }
+      }
+    },
+    "value_changed": {
+      "name": "Response value changed",
+      "description": "Triggers when a field in the JSON response body changes from the previous call.",
+      "fields": {
+        "path": {
+          "name": "Field path",
+          "description": "Dotted path to the field, e.g. 'progress' or 'ams.0.humidity' (list items by index)."
+        }
+      }
+    },
+    "recovered": {
+      "name": "Recovered",
+      "description": "Triggers when a call succeeds (2xx) after the previous call to the endpoint had failed."
+    },
+    "went_down": {
+      "name": "Went down",
+      "description": "Triggers when a call fails after the previous call to the endpoint had succeeded (2xx)."
     }
   }
 }

--- a/custom_components/haapi/translations/en.json
+++ b/custom_components/haapi/translations/en.json
@@ -172,6 +172,52 @@
     "status_changed": {
       "name": "Status code changed",
       "description": "Triggers when the HTTP status code differs from the previous call to the endpoint."
+    },
+    "body_matches": {
+      "name": "Response body matches",
+      "description": "Triggers when the response body matches a regular expression.",
+      "fields": {
+        "pattern": {
+          "name": "Pattern",
+          "description": "Regular expression to search for anywhere in the response body."
+        }
+      }
+    },
+    "value_matches": {
+      "name": "Response value matches",
+      "description": "Triggers when a field in the JSON response body equals or matches a value.",
+      "fields": {
+        "path": {
+          "name": "Field path",
+          "description": "Dotted path to the field, e.g. 'state' or 'ams.0.humidity' (list items by index)."
+        },
+        "equals": {
+          "name": "Equals",
+          "description": "Trigger only when the field equals this value (string comparison). Leave empty to skip."
+        },
+        "pattern": {
+          "name": "Pattern",
+          "description": "Trigger only when the field matches this regular expression. Leave empty to skip."
+        }
+      }
+    },
+    "value_changed": {
+      "name": "Response value changed",
+      "description": "Triggers when a field in the JSON response body changes from the previous call.",
+      "fields": {
+        "path": {
+          "name": "Field path",
+          "description": "Dotted path to the field, e.g. 'progress' or 'ams.0.humidity' (list items by index)."
+        }
+      }
+    },
+    "recovered": {
+      "name": "Recovered",
+      "description": "Triggers when a call succeeds (2xx) after the previous call to the endpoint had failed."
+    },
+    "went_down": {
+      "name": "Went down",
+      "description": "Triggers when a call fails after the previous call to the endpoint had succeeded (2xx)."
     }
   }
 }

--- a/custom_components/haapi/trigger.py
+++ b/custom_components/haapi/trigger.py
@@ -95,7 +95,8 @@ def _resolve_path(body: str | None, path: str) -> Any:
                 index = int(part)
             except ValueError:
                 return _UNSET
-            if not -len(current) <= index < len(current):
+            # Non-negative indices only (JSON-pointer style); reject negatives.
+            if not 0 <= index < len(current):
                 return _UNSET
             current = current[index]
         else:
@@ -325,9 +326,9 @@ class ValueMatchesTrigger(HaapiTrigger):
         pattern = self._options.get(CONF_PATTERN)
         if equals is None and pattern is None:
             return True
-        text = (
-            json.dumps(value) if isinstance(value, (dict, list)) else str(value)
-        )
+        # Compare against the JSON spelling so booleans/null/numbers match what
+        # users see in the body (true/false/null/100.0); raw strings unquoted.
+        text = value if isinstance(value, str) else json.dumps(value)
         if equals is not None and text != str(equals):
             return False
         if pattern is not None and re.search(pattern, text) is None:

--- a/custom_components/haapi/trigger.py
+++ b/custom_components/haapi/trigger.py
@@ -9,6 +9,8 @@ integration fires on every completed call.
 
 from __future__ import annotations
 
+import json
+import re
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -32,13 +34,19 @@ if TYPE_CHECKING:
     )
 
 from .const import (
+    ATTR_BODY,
     ATTR_BODY_CHANGED,
     ATTR_ENDPOINT_ID,
     ATTR_ENDPOINT_NAME,
     ATTR_ENTRY_ID,
     ATTR_OK,
+    ATTR_PREVIOUS_BODY,
+    ATTR_PREVIOUS_STATUS,
     ATTR_STATUS,
     ATTR_STATUS_CHANGED,
+    CONF_EQUALS,
+    CONF_PATH,
+    CONF_PATTERN,
     CONF_STATUS,
     DOMAIN,
     EVENT_HAAPI_RESPONSE,
@@ -55,8 +63,53 @@ _REQUIRED_EVENT_KEYS = frozenset(
         ATTR_OK,
         ATTR_STATUS_CHANGED,
         ATTR_BODY_CHANGED,
+        ATTR_BODY,
+        ATTR_PREVIOUS_STATUS,
+        ATTR_PREVIOUS_BODY,
     }
 )
+
+# Sentinel for "path not resolvable" (distinct from a real None value).
+_UNSET = object()
+
+
+def _resolve_path(body: str | None, path: str) -> Any:
+    """Resolve a dotted path (e.g. ``state`` or ``ams.0.humidity``) in a JSON body.
+
+    Returns the value at the path, or ``_UNSET`` if the body is not JSON or the
+    path does not resolve. List indices are written as integers in the path.
+    """
+    if body is None:
+        return _UNSET
+    try:
+        current = json.loads(body)
+    except (ValueError, TypeError):
+        return _UNSET
+    for part in path.split("."):
+        if isinstance(current, dict):
+            if part not in current:
+                return _UNSET
+            current = current[part]
+        elif isinstance(current, list):
+            try:
+                index = int(part)
+            except ValueError:
+                return _UNSET
+            if not -len(current) <= index < len(current):
+                return _UNSET
+            current = current[index]
+        else:
+            return _UNSET
+    return current
+
+
+def _valid_regex(value: str) -> str:
+    """Validate that a string compiles as a regex."""
+    try:
+        re.compile(value)
+    except re.error as err:
+        raise vol.Invalid(f"Invalid regular expression: {err}") from err
+    return value
 
 _BASE_TRIGGER_SCHEMA = vol.Schema(
     {
@@ -72,6 +125,35 @@ _RESPONSE_RECEIVED_SCHEMA = vol.Schema(
             vol.Optional(CONF_STATUS): vol.All(
                 vol.Coerce(int), vol.Range(min=0, max=599)
             ),
+        },
+    }
+)
+
+_BODY_MATCHES_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_PATTERN): vol.All(cv.string, _valid_regex),
+        },
+    }
+)
+
+_VALUE_MATCHES_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_PATH): cv.string,
+            vol.Optional(CONF_EQUALS): cv.string,
+            vol.Optional(CONF_PATTERN): vol.All(cv.string, _valid_regex),
+        },
+    }
+)
+
+_VALUE_CHANGED_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_PATH): cv.string,
         },
     }
 )
@@ -211,12 +293,96 @@ class StatusChangedTrigger(HaapiTrigger):
         return bool(data[ATTR_STATUS_CHANGED])
 
 
+class BodyMatchesTrigger(HaapiTrigger):
+    """Fire when the response body matches a regular expression."""
+
+    _schema = _BODY_MATCHES_SCHEMA
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        body = data[ATTR_BODY]
+        if body is None:
+            return False
+        return re.search(self._options[CONF_PATTERN], body) is not None
+
+
+class ValueMatchesTrigger(HaapiTrigger):
+    """Fire when a JSON field in the body equals / matches a value.
+
+    ``path`` is a dotted path (``state``, ``ams.0.humidity``). With ``equals``
+    the field must equal that value (string comparison); with ``pattern`` the
+    field must match that regex. With neither, fires whenever the path resolves.
+    """
+
+    _schema = _VALUE_MATCHES_SCHEMA
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        value = _resolve_path(data[ATTR_BODY], self._options[CONF_PATH])
+        if value is _UNSET:
+            return False
+        equals = self._options.get(CONF_EQUALS)
+        pattern = self._options.get(CONF_PATTERN)
+        if equals is None and pattern is None:
+            return True
+        text = (
+            json.dumps(value) if isinstance(value, (dict, list)) else str(value)
+        )
+        if equals is not None and text != str(equals):
+            return False
+        if pattern is not None and re.search(pattern, text) is None:
+            return False
+        return True
+
+
+class ValueChangedTrigger(HaapiTrigger):
+    """Fire when a JSON field in the body changes from the previous call."""
+
+    _schema = _VALUE_CHANGED_SCHEMA
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        path = self._options[CONF_PATH]
+        current = _resolve_path(data[ATTR_BODY], path)
+        if current is _UNSET:
+            return False
+        return current != _resolve_path(data[ATTR_PREVIOUS_BODY], path)
+
+
+class RecoveredTrigger(HaapiTrigger):
+    """Fire when a call succeeds (2xx) after the previous call had failed."""
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        if not data[ATTR_OK]:
+            return False
+        prev = data[ATTR_PREVIOUS_STATUS]
+        return prev is not None and (prev == 0 or prev >= 400)
+
+
+class WentDownTrigger(HaapiTrigger):
+    """Fire when a call fails after the previous call had succeeded (2xx)."""
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        status = data[ATTR_STATUS]
+        if not (status == 0 or status >= 400):
+            return False
+        prev = data[ATTR_PREVIOUS_STATUS]
+        return prev is not None and 200 <= prev < 300
+
+
 TRIGGERS: dict[str, type[Trigger]] = {
     "response_received": ResponseReceivedTrigger,
     "call_succeeded": CallSucceededTrigger,
     "call_failed": CallFailedTrigger,
     "response_changed": ResponseChangedTrigger,
     "status_changed": StatusChangedTrigger,
+    "body_matches": BodyMatchesTrigger,
+    "value_matches": ValueMatchesTrigger,
+    "value_changed": ValueChangedTrigger,
+    "recovered": RecoveredTrigger,
+    "went_down": WentDownTrigger,
 }
 
 

--- a/custom_components/haapi/triggers.yaml
+++ b/custom_components/haapi/triggers.yaml
@@ -24,3 +24,49 @@ call_failed: *endpoint_target
 response_changed: *endpoint_target
 
 status_changed: *endpoint_target
+
+body_matches:
+  target:
+    device:
+      integration: haapi
+  fields:
+    pattern:
+      required: true
+      example: '"state":\s*"FINISH"'
+      selector:
+        text:
+
+value_matches:
+  target:
+    device:
+      integration: haapi
+  fields:
+    path:
+      required: true
+      example: state
+      selector:
+        text:
+    equals:
+      required: false
+      example: FINISH
+      selector:
+        text:
+    pattern:
+      required: false
+      selector:
+        text:
+
+value_changed:
+  target:
+    device:
+      integration: haapi
+  fields:
+    path:
+      required: true
+      example: progress
+      selector:
+        text:
+
+recovered: *endpoint_target
+
+went_down: *endpoint_target

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -314,6 +314,7 @@ from custom_components.haapi.const import (  # noqa: E402
     ATTR_ENDPOINT_NAME,
     ATTR_ENTRY_ID,
     ATTR_OK,
+    ATTR_PREVIOUS_BODY,
     ATTR_PREVIOUS_STATUS,
     ATTR_STATUS,
     ATTR_STATUS_CHANGED,
@@ -351,6 +352,7 @@ async def test_response_event_fired(hass: HomeAssistant, mock_endpoint_config) -
     assert data[ATTR_STATUS_CHANGED] is True
     assert data[ATTR_BODY_CHANGED] is True
     assert data[ATTR_PREVIOUS_STATUS] is None
+    assert data[ATTR_PREVIOUS_BODY] is None
 
 
 async def test_change_detection_across_calls(

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,6 +1,7 @@
 """Tests for the HAAPI trigger platform."""
 
 import pytest
+import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.trigger import TriggerConfig
 
@@ -156,9 +157,28 @@ def test_resolve_path() -> None:
     assert trig._resolve_path(_JSON_BODY, "state") == "FINISH"
     assert trig._resolve_path(_JSON_BODY, "ams.0.humidity") == 25
     assert trig._resolve_path(_JSON_BODY, "ams.5.humidity") is trig._UNSET  # bad index
+    assert trig._resolve_path(_JSON_BODY, "ams.-1.humidity") is trig._UNSET  # no negatives
     assert trig._resolve_path(_JSON_BODY, "missing") is trig._UNSET
     assert trig._resolve_path("not json", "state") is trig._UNSET
     assert trig._resolve_path(None, "state") is trig._UNSET
+
+
+def test_value_matches_json_spelling() -> None:
+    body = '{"connected": true, "progress": 100.0, "child": null}'
+    # JSON booleans/numbers/null match their JSON spelling, not Python's.
+    assert _make(
+        trig.ValueMatchesTrigger, options={"path": "connected", "equals": "true"}
+    )._event_matches(_data(body=body)) is True
+    assert _make(
+        trig.ValueMatchesTrigger, options={"path": "progress", "equals": "100.0"}
+    )._event_matches(_data(body=body)) is True
+    assert _make(
+        trig.ValueMatchesTrigger, options={"path": "child", "equals": "null"}
+    )._event_matches(_data(body=body)) is True
+    # Python spelling does NOT match.
+    assert _make(
+        trig.ValueMatchesTrigger, options={"path": "connected", "equals": "True"}
+    )._event_matches(_data(body=body)) is False
 
 
 def test_body_matches() -> None:
@@ -230,12 +250,12 @@ async def test_validate_config_content_triggers(hass: HomeAssistant) -> None:
     assert cfg2["options"]["path"] == "state"
 
     # invalid regex is rejected
-    with pytest.raises(Exception):
+    with pytest.raises(vol.Invalid):
         await trig.BodyMatchesTrigger.async_validate_config(
             hass, {"options": {"pattern": "("}}
         )
     # missing required path is rejected
-    with pytest.raises(Exception):
+    with pytest.raises(vol.Invalid):
         await trig.ValueChangedTrigger.async_validate_config(hass, {"options": {}})
 
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -13,6 +13,7 @@ from custom_components.haapi.const import (
     ATTR_ENTRY_ID,
     ATTR_HEADERS,
     ATTR_OK,
+    ATTR_PREVIOUS_BODY,
     ATTR_PREVIOUS_STATUS,
     ATTR_STATUS,
     ATTR_STATUS_CHANGED,
@@ -35,6 +36,7 @@ def _data(**over):
         ATTR_STATUS_CHANGED: True,
         ATTR_BODY_CHANGED: True,
         ATTR_PREVIOUS_STATUS: None,
+        ATTR_PREVIOUS_BODY: None,
     }
     base.update(over)
     return base
@@ -45,7 +47,7 @@ def _make(cls, options=None, target=None, hass=None):
 
 
 async def test_get_triggers(hass: HomeAssistant) -> None:
-    """All five triggers are exposed."""
+    """All triggers are exposed."""
     triggers = await trig.async_get_triggers(hass)
     assert set(triggers) == {
         "response_received",
@@ -53,6 +55,11 @@ async def test_get_triggers(hass: HomeAssistant) -> None:
         "call_failed",
         "response_changed",
         "status_changed",
+        "body_matches",
+        "value_matches",
+        "value_changed",
+        "recovered",
+        "went_down",
     }
 
 
@@ -135,4 +142,118 @@ async def test_attach_runner_status_filter(hass: HomeAssistant) -> None:
 
     assert len(calls) == 1
     assert calls[0][ATTR_STATUS] == 429
+    unsub()
+
+
+# ---------------------------------------------------------------------------
+# Content / JSON-path / health-edge triggers (2.8.0)
+# ---------------------------------------------------------------------------
+
+_JSON_BODY = '{"state": "FINISH", "progress": 100.0, "ams": [{"humidity": 25}]}'
+
+
+def test_resolve_path() -> None:
+    assert trig._resolve_path(_JSON_BODY, "state") == "FINISH"
+    assert trig._resolve_path(_JSON_BODY, "ams.0.humidity") == 25
+    assert trig._resolve_path(_JSON_BODY, "ams.5.humidity") is trig._UNSET  # bad index
+    assert trig._resolve_path(_JSON_BODY, "missing") is trig._UNSET
+    assert trig._resolve_path("not json", "state") is trig._UNSET
+    assert trig._resolve_path(None, "state") is trig._UNSET
+
+
+def test_body_matches() -> None:
+    t = _make(trig.BodyMatchesTrigger, options={"pattern": r'"state":\s*"FINISH"'})
+    assert t._event_matches(_data(body=_JSON_BODY)) is True
+    assert t._event_matches(_data(body='{"state": "RUNNING"}')) is False
+    assert t._event_matches(_data(body=None)) is False
+
+
+def test_value_matches_equals_and_pattern() -> None:
+    eq = _make(trig.ValueMatchesTrigger, options={"path": "state", "equals": "FINISH"})
+    assert eq._event_matches(_data(body=_JSON_BODY)) is True
+    assert eq._event_matches(_data(body='{"state": "RUNNING"}')) is False
+    # missing path
+    assert eq._event_matches(_data(body='{"x": 1}')) is False
+
+    pat = _make(trig.ValueMatchesTrigger, options={"path": "state", "pattern": "^FIN"})
+    assert pat._event_matches(_data(body=_JSON_BODY)) is True
+
+    # neither equals nor pattern -> fires when path resolves
+    exists = _make(trig.ValueMatchesTrigger, options={"path": "ams.0.humidity"})
+    assert exists._event_matches(_data(body=_JSON_BODY)) is True
+    assert exists._event_matches(_data(body='{"x": 1}')) is False
+
+
+def test_value_changed() -> None:
+    t = _make(trig.ValueChangedTrigger, options={"path": "state"})
+    # changed
+    assert t._event_matches(
+        _data(body='{"state": "FINISH"}', previous_body='{"state": "RUNNING"}')
+    ) is True
+    # same
+    assert t._event_matches(
+        _data(body='{"state": "FINISH"}', previous_body='{"state": "FINISH"}')
+    ) is False
+    # first call (no previous body) counts as changed
+    assert t._event_matches(_data(body='{"state": "FINISH"}', previous_body=None)) is True
+    # path missing in current -> no fire
+    assert t._event_matches(_data(body='{"x": 1}', previous_body='{"state": "A"}')) is False
+
+
+def test_recovered() -> None:
+    t = _make(trig.RecoveredTrigger)
+    assert t._event_matches(_data(ok=True, status=200, previous_status=500)) is True
+    assert t._event_matches(_data(ok=True, status=200, previous_status=0)) is True
+    assert t._event_matches(_data(ok=True, status=200, previous_status=200)) is False
+    assert t._event_matches(_data(ok=True, status=200, previous_status=None)) is False
+    assert t._event_matches(_data(ok=False, status=500, previous_status=500)) is False
+
+
+def test_went_down() -> None:
+    t = _make(trig.WentDownTrigger)
+    assert t._event_matches(_data(ok=False, status=500, previous_status=200)) is True
+    assert t._event_matches(_data(ok=False, status=0, previous_status=204)) is True
+    assert t._event_matches(_data(ok=True, status=200, previous_status=200)) is False
+    assert t._event_matches(_data(ok=False, status=500, previous_status=None)) is False
+    assert t._event_matches(_data(ok=False, status=500, previous_status=500)) is False
+
+
+async def test_validate_config_content_triggers(hass: HomeAssistant) -> None:
+    cfg = await trig.BodyMatchesTrigger.async_validate_config(
+        hass, {"options": {"pattern": "ok"}}
+    )
+    assert cfg["options"]["pattern"] == "ok"
+
+    cfg2 = await trig.ValueMatchesTrigger.async_validate_config(
+        hass, {"options": {"path": "state", "equals": "FINISH"}}
+    )
+    assert cfg2["options"]["path"] == "state"
+
+    # invalid regex is rejected
+    with pytest.raises(Exception):
+        await trig.BodyMatchesTrigger.async_validate_config(
+            hass, {"options": {"pattern": "("}}
+        )
+    # missing required path is rejected
+    with pytest.raises(Exception):
+        await trig.ValueChangedTrigger.async_validate_config(hass, {"options": {}})
+
+
+async def test_attach_value_matches_end_to_end(hass: HomeAssistant) -> None:
+    """Full bus path for a content trigger, incl. the malformed-event guard."""
+    calls: list[dict] = []
+    t = _make(
+        trig.ValueMatchesTrigger,
+        options={"path": "state", "equals": "FINISH"},
+        hass=hass,
+    )
+    unsub = await t.async_attach_runner(lambda p, d, c=None: calls.append(p))
+
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, _data(body='{"state": "RUNNING"}'))
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HAAPI_RESPONSE, _data(body='{"state": "FINISH"}'))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0]["platform"] == "haapi.ValueMatchesTrigger"
     unsub()


### PR DESCRIPTION
## What
Builds on the trigger platform (#12) with five new integration triggers, taking the set from 5 → 10.

| Trigger | Fires when |
| --- | --- |
| `haapi.body_matches` | The response body matches a regex (`pattern`). |
| `haapi.value_matches` | A JSON field (`path`, e.g. `state` / `ams.0.humidity`) `equals` a value or matches a `pattern`. With neither, fires when the path resolves. |
| `haapi.value_changed` | A JSON field differs from the previous call (field-level `response_changed`). |
| `haapi.recovered` | A call succeeds (2xx) after the previous call had failed. |
| `haapi.went_down` | A call fails after the previous call had succeeded (2xx). |

## How
- **Lightweight dotted-path resolver** (dict keys + list indices, e.g. `ams.0.humidity`) — no JSONPath dependency. Directly satisfies the open *"Add built-in JSON path extraction"* request and powers `value_matches` / `value_changed`. Non-JSON body or unresolvable path → the value triggers simply don't fire.
- The `haapi_response` event now also carries **`previous_body`** so `value_changed` can diff a field across calls (backward-compatible — one more field).
- Regex `pattern` options are validated at config time (clear error on a bad regex).
- The malformed-event guard now also requires `body` / `previous_body` / `previous_status`.
- `triggers.yaml`, `strings.json` + `en` translations, and the README are updated; version → **2.8.0**.

## Tests
Added coverage for the resolver, all five new triggers (incl. equals/pattern/missing-path/first-call cases), config validation (incl. invalid-regex rejection), and an end-to-end bus test. **Suite: 38 passed** locally; CI runs on this PR.

Follow-up (separate PR): conditions (`last_call_succeeded`, `response_contains`, `value_is`).