### PR TITLE
Integration conditions (2.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A universal API integration framework for Home Assistant 2025.11+ where each "de
 - [Configuration](#configuration)
 - [Entities](#entities)
 - [Triggers](#triggers)
+- [Conditions](#conditions)
 - [Usage](#usage)
   - [Quick Start Examples](#quick-start-examples)
   - [Template Support](#template-support)
@@ -28,7 +29,8 @@ A universal API integration framework for Home Assistant 2025.11+ where each "de
 - **Template Support**: Use Jinja2 templates in URLs, headers, and request bodies
 - **Multiple Auth Types**: None, Basic, Bearer Token, or API Key authentication
 - **Response Storage**: Capture HTTP status codes, response bodies, and headers
-- **Integration Triggers**: React to call completions directly in automations (success, failure, response changed, status changed) — no `delay` + state-watch workarounds
+- **Integration Triggers**: React to call completions directly in automations (success, failure, response/status changed, body/JSON-field match) — no `delay` + state-watch workarounds
+- **Integration Conditions**: Gate automations on the last call's result (succeeded, body contains, JSON field is) without templating
 - **Modern HA Standards**: Built with config flow and proper entity platforms
 
 ## Installation
@@ -186,6 +188,35 @@ automation:
       - action: notify.mobile_app
         data:
           message: "Print finished"
+```
+
+## Conditions
+
+*Requires Home Assistant 2026.7 or later.*
+
+HAAPI also provides integration-specific **conditions** so an automation can gate on the result of an endpoint's most recent call without templating. Each condition targets one or more endpoint devices (with multiple, all must satisfy it) and is evaluated live against the stored response.
+
+| Condition | Passes when |
+| --- | --- |
+| **Last call succeeded** | The endpoint's last call returned a `2xx` status. |
+| **Response contains** | The last response body matches a regex (`pattern`). |
+| **Response value is** | A JSON field (`path`) `equals` a value or matches a `pattern`. With neither, passes whenever the path resolves. |
+
+**Example** — only act if the last status fetch succeeded:
+```yaml
+automation:
+  - alias: "Refresh only when API is healthy"
+    trigger:
+      - trigger: time_pattern
+        minutes: "/5"
+    condition:
+      - condition: haapi.last_call_succeeded
+        target:
+          device_id: <your HAAPI endpoint device>
+    action:
+      - action: button.press
+        target:
+          entity_id: button.my_endpoint_trigger
 ```
 
 ## Usage

--- a/custom_components/haapi/condition.py
+++ b/custom_components/haapi/condition.py
@@ -1,0 +1,186 @@
+"""Condition platform for the HAAPI integration.
+
+Integration-specific conditions (Home Assistant 2026.7+) so automations can gate
+on the result of an endpoint's most recent call without templating. Each
+condition is evaluated against the live stored response for the targeted
+endpoint device(s); with multiple targets, all must satisfy the condition.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS, CONF_TARGET
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.condition import Condition
+from homeassistant.helpers.target import (
+    TargetSelection,
+    async_extract_referenced_entity_ids,
+)
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from .const import CONF_EQUALS, CONF_PATH, CONF_PATTERN, DOMAIN
+from .matching import UNSET, resolve_path, valid_regex, value_text
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.condition import ConditionChecker, ConditionConfig
+
+_BASE_CONDITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS, default={}): {},
+    }
+)
+
+_RESPONSE_CONTAINS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_PATTERN): vol.All(cv.string, valid_regex),
+        },
+    }
+)
+
+_VALUE_IS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_PATH): cv.string,
+            vol.Optional(CONF_EQUALS): cv.string,
+            vol.Optional(CONF_PATTERN): vol.All(cv.string, valid_regex),
+        },
+    }
+)
+
+
+class HaapiCondition(Condition):
+    """Base class for HAAPI conditions evaluated against the last response.
+
+    Subclasses define ``_predicate`` against a single endpoint's API caller; the
+    condition is true when every targeted endpoint satisfies it.
+    """
+
+    _schema: vol.Schema = _BASE_CONDITION_SCHEMA
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate the condition config."""
+        return cls._schema(config)
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        self._target = config.target
+        self._options = config.options or {}
+
+    def _api_callers(self) -> list:
+        """Resolve the configured target to HAAPI endpoint API callers."""
+        if not self._target:
+            return []
+        selection = TargetSelection(self._target)
+        if not selection.has_any_target:
+            return []
+
+        selected = async_extract_referenced_entity_ids(self._hass, selection)
+        ent_reg = er.async_get(self._hass)
+        dev_reg = dr.async_get(self._hass)
+
+        device_ids: set[str] = set(selected.referenced_devices)
+        for entity_id in selected.referenced | selected.indirectly_referenced:
+            entry = ent_reg.async_get(entity_id)
+            if entry and entry.device_id:
+                device_ids.add(entry.device_id)
+
+        domain_data = self._hass.data.get(DOMAIN, {})
+        callers: list = []
+        for device_id in device_ids:
+            device = dev_reg.async_get(device_id)
+            if not device:
+                continue
+            for domain, identifier in device.identifiers:
+                if domain != DOMAIN:
+                    continue
+                entry_id, _, endpoint_id = identifier.partition("_")
+                coordinator = domain_data.get(entry_id)
+                if coordinator is None:
+                    continue
+                caller = coordinator.get_api_caller(endpoint_id)
+                if caller is not None:
+                    callers.append(caller)
+        return callers
+
+    def _predicate(self, caller) -> bool:
+        """Return whether a single endpoint's last response satisfies this."""
+        raise NotImplementedError
+
+    async def async_get_checker(self) -> ConditionChecker:
+        """Return a checker that evaluates the condition against live state."""
+
+        @callback
+        def _check(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+            callers = self._api_callers()
+            if not callers:
+                return False
+            return all(self._predicate(caller) for caller in callers)
+
+        return _check
+
+
+class LastCallSucceededCondition(HaapiCondition):
+    """True when the endpoint's last call returned a 2xx status."""
+
+    def _predicate(self, caller) -> bool:
+        code = caller.last_response_code
+        return code is not None and 200 <= code < 300
+
+
+class ResponseContainsCondition(HaapiCondition):
+    """True when the endpoint's last response body matches a regex."""
+
+    _schema = _RESPONSE_CONTAINS_SCHEMA
+
+    def _predicate(self, caller) -> bool:
+        body = caller.last_response_body
+        if body is None:
+            return False
+        return re.search(self._options[CONF_PATTERN], body) is not None
+
+
+class ValueIsCondition(HaapiCondition):
+    """True when a JSON field in the last response equals / matches a value."""
+
+    _schema = _VALUE_IS_SCHEMA
+
+    def _predicate(self, caller) -> bool:
+        value = resolve_path(caller.last_response_body, self._options[CONF_PATH])
+        if value is UNSET:
+            return False
+        equals = self._options.get(CONF_EQUALS)
+        pattern = self._options.get(CONF_PATTERN)
+        if equals is None and pattern is None:
+            return True
+        text = value_text(value)
+        if equals is not None and text != str(equals):
+            return False
+        if pattern is not None and re.search(pattern, text) is None:
+            return False
+        return True
+
+
+CONDITIONS: dict[str, type[Condition]] = {
+    "last_call_succeeded": LastCallSucceededCondition,
+    "response_contains": ResponseContainsCondition,
+    "value_is": ValueIsCondition,
+}
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
+    """Return the conditions provided by HAAPI."""
+    return CONDITIONS

--- a/custom_components/haapi/conditions.yaml
+++ b/custom_components/haapi/conditions.yaml
@@ -1,0 +1,37 @@
+.endpoint_target: &endpoint_target
+  target:
+    device:
+      integration: haapi
+
+last_call_succeeded: *endpoint_target
+
+response_contains:
+  target:
+    device:
+      integration: haapi
+  fields:
+    pattern:
+      required: true
+      example: '"state":\s*"FINISH"'
+      selector:
+        text:
+
+value_is:
+  target:
+    device:
+      integration: haapi
+  fields:
+    path:
+      required: true
+      example: state
+      selector:
+        text:
+    equals:
+      required: false
+      example: FINISH
+      selector:
+        text:
+    pattern:
+      required: false
+      selector:
+        text:

--- a/custom_components/haapi/manifest.json
+++ b/custom_components/haapi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nasawa/HAAPI/issues",
   "requirements": [],
-  "version": "2.8.0"
+  "version": "2.9.0"
 }

--- a/custom_components/haapi/matching.py
+++ b/custom_components/haapi/matching.py
@@ -1,0 +1,65 @@
+"""Shared body-matching helpers for HAAPI triggers and conditions.
+
+A lightweight dotted-path resolver over a JSON body (no JSONPath dependency)
+plus small helpers for regex validation and JSON-spelling comparisons.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import voluptuous as vol
+
+# Sentinel for "path not resolvable" (distinct from a real None value).
+UNSET = object()
+
+
+def resolve_path(body: str | None, path: str) -> Any:
+    """Resolve a dotted path (e.g. ``state`` or ``ams.0.humidity``) in a JSON body.
+
+    Returns the value at the path, or ``UNSET`` if the body is not JSON or the
+    path does not resolve. List indices are non-negative integers in the path.
+    """
+    if body is None:
+        return UNSET
+    try:
+        current = json.loads(body)
+    except (ValueError, TypeError):
+        return UNSET
+    for part in path.split("."):
+        if isinstance(current, dict):
+            if part not in current:
+                return UNSET
+            current = current[part]
+        elif isinstance(current, list):
+            try:
+                index = int(part)
+            except ValueError:
+                return UNSET
+            # Non-negative indices only (JSON-pointer style); reject negatives.
+            if not 0 <= index < len(current):
+                return UNSET
+            current = current[index]
+        else:
+            return UNSET
+    return current
+
+
+def value_text(value: Any) -> str:
+    """Render a resolved value for comparison.
+
+    Strings are returned raw; everything else uses its JSON spelling so
+    booleans/null/numbers match what users see in the body (true/false/null).
+    """
+    return value if isinstance(value, str) else json.dumps(value)
+
+
+def valid_regex(value: str) -> str:
+    """Validate that a string compiles as a regex (voluptuous validator)."""
+    try:
+        re.compile(value)
+    except re.error as err:
+        raise vol.Invalid(f"Invalid regular expression: {err}") from err
+    return value

--- a/custom_components/haapi/strings.json
+++ b/custom_components/haapi/strings.json
@@ -219,5 +219,39 @@
       "name": "Went down",
       "description": "Triggers when a call fails after the previous call to the endpoint had succeeded (2xx)."
     }
+  },
+  "conditions": {
+    "last_call_succeeded": {
+      "name": "Last call succeeded",
+      "description": "Passes when the endpoint's last call returned a 2xx status."
+    },
+    "response_contains": {
+      "name": "Response contains",
+      "description": "Passes when the endpoint's last response body matches a regular expression.",
+      "fields": {
+        "pattern": {
+          "name": "Pattern",
+          "description": "Regular expression to search for anywhere in the last response body."
+        }
+      }
+    },
+    "value_is": {
+      "name": "Response value is",
+      "description": "Passes when a field in the last JSON response body equals or matches a value.",
+      "fields": {
+        "path": {
+          "name": "Field path",
+          "description": "Dotted path to the field, e.g. 'state' or 'ams.0.humidity' (list items by index)."
+        },
+        "equals": {
+          "name": "Equals",
+          "description": "Pass only when the field equals this value (string comparison). Leave empty to skip."
+        },
+        "pattern": {
+          "name": "Pattern",
+          "description": "Pass only when the field matches this regular expression. Leave empty to skip."
+        }
+      }
+    }
   }
 }

--- a/custom_components/haapi/translations/en.json
+++ b/custom_components/haapi/translations/en.json
@@ -219,5 +219,39 @@
       "name": "Went down",
       "description": "Triggers when a call fails after the previous call to the endpoint had succeeded (2xx)."
     }
+  },
+  "conditions": {
+    "last_call_succeeded": {
+      "name": "Last call succeeded",
+      "description": "Passes when the endpoint's last call returned a 2xx status."
+    },
+    "response_contains": {
+      "name": "Response contains",
+      "description": "Passes when the endpoint's last response body matches a regular expression.",
+      "fields": {
+        "pattern": {
+          "name": "Pattern",
+          "description": "Regular expression to search for anywhere in the last response body."
+        }
+      }
+    },
+    "value_is": {
+      "name": "Response value is",
+      "description": "Passes when a field in the last JSON response body equals or matches a value.",
+      "fields": {
+        "path": {
+          "name": "Field path",
+          "description": "Dotted path to the field, e.g. 'state' or 'ams.0.humidity' (list items by index)."
+        },
+        "equals": {
+          "name": "Equals",
+          "description": "Pass only when the field equals this value (string comparison). Leave empty to skip."
+        },
+        "pattern": {
+          "name": "Pattern",
+          "description": "Pass only when the field matches this regular expression. Leave empty to skip."
+        }
+      }
+    }
   }
 }

--- a/custom_components/haapi/trigger.py
+++ b/custom_components/haapi/trigger.py
@@ -9,7 +9,6 @@ integration fires on every completed call.
 
 from __future__ import annotations
 
-import json
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -51,6 +50,10 @@ from .const import (
     DOMAIN,
     EVENT_HAAPI_RESPONSE,
 )
+from .matching import UNSET as _UNSET
+from .matching import resolve_path as _resolve_path
+from .matching import valid_regex as _valid_regex
+from .matching import value_text
 
 # Keys every subclass reads off the event payload; used to drop malformed
 # haapi_response events fired by foreign automations on the global bus.
@@ -68,49 +71,6 @@ _REQUIRED_EVENT_KEYS = frozenset(
         ATTR_PREVIOUS_BODY,
     }
 )
-
-# Sentinel for "path not resolvable" (distinct from a real None value).
-_UNSET = object()
-
-
-def _resolve_path(body: str | None, path: str) -> Any:
-    """Resolve a dotted path (e.g. ``state`` or ``ams.0.humidity``) in a JSON body.
-
-    Returns the value at the path, or ``_UNSET`` if the body is not JSON or the
-    path does not resolve. List indices are written as integers in the path.
-    """
-    if body is None:
-        return _UNSET
-    try:
-        current = json.loads(body)
-    except (ValueError, TypeError):
-        return _UNSET
-    for part in path.split("."):
-        if isinstance(current, dict):
-            if part not in current:
-                return _UNSET
-            current = current[part]
-        elif isinstance(current, list):
-            try:
-                index = int(part)
-            except ValueError:
-                return _UNSET
-            # Non-negative indices only (JSON-pointer style); reject negatives.
-            if not 0 <= index < len(current):
-                return _UNSET
-            current = current[index]
-        else:
-            return _UNSET
-    return current
-
-
-def _valid_regex(value: str) -> str:
-    """Validate that a string compiles as a regex."""
-    try:
-        re.compile(value)
-    except re.error as err:
-        raise vol.Invalid(f"Invalid regular expression: {err}") from err
-    return value
 
 _BASE_TRIGGER_SCHEMA = vol.Schema(
     {
@@ -328,7 +288,7 @@ class ValueMatchesTrigger(HaapiTrigger):
             return True
         # Compare against the JSON spelling so booleans/null/numbers match what
         # users see in the body (true/false/null/100.0); raw strings unquoted.
-        text = value if isinstance(value, str) else json.dumps(value)
+        text = value_text(value)
         if equals is not None and text != str(equals):
             return False
         if pattern is not None and re.search(pattern, text) is None:

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -1,0 +1,142 @@
+"""Tests for the HAAPI condition platform."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.condition import ConditionConfig
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haapi import condition as cond
+from custom_components.haapi.const import DOMAIN
+
+_ENDPOINT_ID = "test-endpoint-id"
+
+
+@pytest.fixture
+async def endpoint(hass, mock_config_entry_data, mock_config_entry_options):
+    """Set up a loaded entry and return its api caller + device id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_config_entry_data,
+        options=mock_config_entry_options,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.haapi.Store.async_load", return_value={}):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    caller = coordinator.get_api_caller(_ENDPOINT_ID)
+    device = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, f"{entry.entry_id}_{_ENDPOINT_ID}")}
+    )
+    return SimpleNamespace(caller=caller, device_id=device.id)
+
+
+def _make(cls, device_id, options=None):
+    return cls(
+        None,
+        ConditionConfig(options=options or {}, target={"device_id": [device_id]}),
+    )
+
+
+def _set_response(caller, code, body=None):
+    caller._last_response_code = code
+    caller._last_response_body = body
+
+
+async def test_get_conditions(hass: HomeAssistant) -> None:
+    conditions = await cond.async_get_conditions(hass)
+    assert set(conditions) == {
+        "last_call_succeeded",
+        "response_contains",
+        "value_is",
+    }
+
+
+async def test_last_call_succeeded(hass: HomeAssistant, endpoint) -> None:
+    c = _make(cond.LastCallSucceededCondition, endpoint.device_id)
+    c._hass = hass
+    check = await c.async_get_checker()
+
+    _set_response(endpoint.caller, 200, "ok")
+    assert check(hass, {}) is True
+    _set_response(endpoint.caller, 500, "err")
+    assert check(hass, {}) is False
+    _set_response(endpoint.caller, None, None)
+    assert check(hass, {}) is False
+
+
+async def test_response_contains(hass: HomeAssistant, endpoint) -> None:
+    c = _make(
+        cond.ResponseContainsCondition,
+        endpoint.device_id,
+        options={"pattern": r'"state":\s*"FINISH"'},
+    )
+    c._hass = hass
+    check = await c.async_get_checker()
+
+    _set_response(endpoint.caller, 200, '{"state": "FINISH"}')
+    assert check(hass, {}) is True
+    _set_response(endpoint.caller, 200, '{"state": "RUNNING"}')
+    assert check(hass, {}) is False
+    _set_response(endpoint.caller, 200, None)
+    assert check(hass, {}) is False
+
+
+async def test_value_is(hass: HomeAssistant, endpoint) -> None:
+    c = _make(
+        cond.ValueIsCondition,
+        endpoint.device_id,
+        options={"path": "state", "equals": "FINISH"},
+    )
+    c._hass = hass
+    check = await c.async_get_checker()
+
+    _set_response(endpoint.caller, 200, '{"state": "FINISH"}')
+    assert check(hass, {}) is True
+    _set_response(endpoint.caller, 200, '{"state": "RUNNING"}')
+    assert check(hass, {}) is False
+    _set_response(endpoint.caller, 200, '{"other": 1}')  # path missing
+    assert check(hass, {}) is False
+
+
+async def test_value_is_json_spelling(hass: HomeAssistant, endpoint) -> None:
+    c = _make(
+        cond.ValueIsCondition,
+        endpoint.device_id,
+        options={"path": "connected", "equals": "true"},
+    )
+    c._hass = hass
+    check = await c.async_get_checker()
+    _set_response(endpoint.caller, 200, '{"connected": true}')
+    assert check(hass, {}) is True
+
+
+async def test_checker_false_when_target_unresolvable(hass: HomeAssistant) -> None:
+    """No matching HAAPI device -> condition is False, not an error."""
+    c = _make(cond.LastCallSucceededCondition, "does-not-exist")
+    c._hass = hass
+    check = await c.async_get_checker()
+    assert check(hass, {}) is False
+
+
+async def test_validate_config(hass: HomeAssistant) -> None:
+    cfg = await cond.ResponseContainsCondition.async_validate_config(
+        hass, {"target": {"device_id": ["x"]}, "options": {"pattern": "ok"}}
+    )
+    assert cfg["options"]["pattern"] == "ok"
+
+    with pytest.raises(vol.Invalid):
+        await cond.ResponseContainsCondition.async_validate_config(
+            hass, {"target": {"device_id": ["x"]}, "options": {"pattern": "("}}
+        )
+    with pytest.raises(vol.Invalid):
+        await cond.ValueIsCondition.async_validate_config(
+            hass, {"target": {"device_id": ["x"]}, "options": {}}
+        )


### PR DESCRIPTION
## What
Adds the **conditions** half of the 2026.7 integration-automation surface, so automations can gate on an endpoint's most recent call without templating.

| Condition | Passes when |
| --- | --- |
| `haapi.last_call_succeeded` | The endpoint's last call returned a `2xx` status. |
| `haapi.response_contains` | The last response body matches a regex (`pattern`). |
| `haapi.value_is` | A JSON field (`path`, e.g. `state` / `ams.0.humidity`) `equals` a value or matches a `pattern`. With neither, passes when the path resolves. |

Each condition targets one or more endpoint devices (with multiple, **all** must satisfy it) and is evaluated live against the coordinator's stored response.

## How
- New `condition.py` (`CONDITIONS` + `async_get_conditions`) implementing the `Condition` platform; each condition's checker resolves the target device(s) → endpoint API caller(s) and evaluates against `last_response_code` / `last_response_body`.
- **Refactor:** the dotted-path resolver, regex validator, and JSON-spelling helper move to a shared `custom_components/haapi/matching.py`, now used by both `trigger.py` and `condition.py`. `trigger.py` re-exports the old private names — **no behavior change** (trigger tests unchanged and green).
- `conditions.yaml` + `strings.json`/`en` translations + README added; version → **2.9.0**.

## Tests
Added `tests/test_condition.py` (loads an entry, sets a stored response, evaluates each condition incl. JSON-spelling, missing-path, unresolvable-target → False, and config validation). **Suite: 46 passed**; CI runs on this PR.

This completes the trigger + condition family. Next (separate, HA-side): redeploy the integration to the HA instance, then consolidate the GitHub-PR-watch automations onto the new triggers/conditions.