### PR TITLE
haapi.request action returning response data (2.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A universal API integration framework for Home Assistant 2025.11+ where each "de
 - [Entities](#entities)
 - [Triggers](#triggers)
 - [Conditions](#conditions)
+- [Actions](#actions)
 - [Usage](#usage)
   - [Quick Start Examples](#quick-start-examples)
   - [Template Support](#template-support)
@@ -31,6 +32,7 @@ A universal API integration framework for Home Assistant 2025.11+ where each "de
 - **Response Storage**: Capture HTTP status codes, response bodies, and headers
 - **Integration Triggers**: React to call completions directly in automations (success, failure, response/status changed, body/JSON-field match) — no `delay` + state-watch workarounds
 - **Integration Conditions**: Gate automations on the last call's result (succeeded, body contains, JSON field is) without templating
+- **Request Action**: `haapi.request` calls an endpoint and returns its response in the same step (`response_variable`) — no button + wait/delay race
 - **Modern HA Standards**: Built with config flow and proper entity platforms
 
 ## Installation
@@ -218,6 +220,35 @@ automation:
         target:
           entity_id: button.my_endpoint_trigger
 ```
+
+## Actions
+
+### `haapi.request`
+
+Calls a single targeted endpoint and **returns its response**, so an automation can use the result in the very next step — no button-press + `wait`/`delay`, and no race. Target a single HAAPI endpoint device.
+
+Returns: `endpoint_id`, `endpoint_name`, `status`, `ok`, `body`, `headers`, `truncated`.
+
+```yaml
+automation:
+  - alias: "Clear the plate when a finished print is detected"
+    trigger:
+      - trigger: state
+        entity_id: binary_sensor.printer_door
+        from: "on"
+        to: "off"
+    action:
+      - action: haapi.request          # fetch fresh status, get the response back
+        target:
+          device_id: <status endpoint device>
+        response_variable: status
+      - condition: "{{ (status.body | from_json).awaiting_plate_clear }}"
+      - action: haapi.request          # clear-plate endpoint
+        target:
+          device_id: <clear-plate endpoint device>
+```
+
+This is the synchronous counterpart to the endpoint's **Trigger** button: the button is fire-and-forget (great for dashboards), while `haapi.request` awaits the call and hands you the response.
 
 ## Usage
 

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -14,11 +14,18 @@ import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.helpers import template
 from homeassistant.helpers.storage import Store
-from homeassistant.exceptions import TemplateError
+from homeassistant.exceptions import ServiceValidationError, TemplateError
 from homeassistant.util import dt as dt_util
+
+from .resolve import endpoint_callers
 
 from .const import (
     DOMAIN,
@@ -68,6 +75,41 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
+
+SERVICE_REQUEST = "request"
+
+
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
+    """Set up HAAPI (registers the request action)."""
+
+    async def _async_handle_request(call: ServiceCall) -> ServiceResponse:
+        """Call a single targeted endpoint and return its response."""
+        callers = endpoint_callers(hass, dict(call.data))
+        if len(callers) != 1:
+            raise ServiceValidationError(
+                "haapi.request requires a target that resolves to exactly one "
+                f"HAAPI endpoint (resolved {len(callers)})"
+            )
+        caller = callers[0]
+        await caller.async_call_api()
+        status = caller.last_response_code or 0
+        return {
+            ATTR_ENDPOINT_ID: caller.endpoint_id,
+            ATTR_ENDPOINT_NAME: caller.endpoint_name,
+            ATTR_STATUS: status,
+            ATTR_OK: 200 <= status < 300,
+            ATTR_BODY: caller.last_response_body,
+            ATTR_HEADERS: caller.last_response_headers or {},
+            ATTR_TRUNCATED: caller.truncated,
+        }
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REQUEST,
+        _async_handle_request,
+        supports_response=SupportsResponse.ONLY,
+    )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import template
 from homeassistant.helpers.storage import Store
 from homeassistant.exceptions import ServiceValidationError, TemplateError
@@ -75,6 +76,10 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
+
+# HAAPI is configured only via config entries (the request service has no YAML
+# config), so declare the config-entry-only schema.
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 SERVICE_REQUEST = "request"
 

--- a/custom_components/haapi/condition.py
+++ b/custom_components/haapi/condition.py
@@ -16,16 +16,12 @@ import voluptuous as vol
 from homeassistant.const import CONF_OPTIONS, CONF_TARGET
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.condition import Condition
-from homeassistant.helpers.target import (
-    TargetSelection,
-    async_extract_referenced_entity_ids,
-)
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from .const import CONF_EQUALS, CONF_PATH, CONF_PATTERN, DOMAIN
+from .const import CONF_EQUALS, CONF_PATH, CONF_PATTERN
 from .matching import UNSET, resolve_path, valid_regex, value_text
+from .resolve import endpoint_callers
 
 if TYPE_CHECKING:
     from homeassistant.helpers.condition import ConditionChecker, ConditionConfig
@@ -80,42 +76,6 @@ class HaapiCondition(Condition):
         self._target = config.target
         self._options = config.options or {}
 
-    def _api_callers(self) -> list:
-        """Resolve the configured target to HAAPI endpoint API callers."""
-        if not self._target:
-            return []
-        selection = TargetSelection(self._target)
-        if not selection.has_any_target:
-            return []
-
-        selected = async_extract_referenced_entity_ids(self._hass, selection)
-        ent_reg = er.async_get(self._hass)
-        dev_reg = dr.async_get(self._hass)
-
-        device_ids: set[str] = set(selected.referenced_devices)
-        for entity_id in selected.referenced | selected.indirectly_referenced:
-            entry = ent_reg.async_get(entity_id)
-            if entry and entry.device_id:
-                device_ids.add(entry.device_id)
-
-        domain_data = self._hass.data.get(DOMAIN, {})
-        callers: list = []
-        for device_id in device_ids:
-            device = dev_reg.async_get(device_id)
-            if not device:
-                continue
-            for domain, identifier in device.identifiers:
-                if domain != DOMAIN:
-                    continue
-                entry_id, _, endpoint_id = identifier.partition("_")
-                coordinator = domain_data.get(entry_id)
-                if coordinator is None:
-                    continue
-                caller = coordinator.get_api_caller(endpoint_id)
-                if caller is not None:
-                    callers.append(caller)
-        return callers
-
     def _predicate(self, caller) -> bool:
         """Return whether a single endpoint's last response satisfies this."""
         raise NotImplementedError
@@ -125,7 +85,7 @@ class HaapiCondition(Condition):
 
         @callback
         def _check(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
-            callers = self._api_callers()
+            callers = endpoint_callers(self._hass, self._target)
             if not callers:
                 return False
             return all(self._predicate(caller) for caller in callers)

--- a/custom_components/haapi/manifest.json
+++ b/custom_components/haapi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nasawa/HAAPI/issues",
   "requirements": [],
-  "version": "2.9.0"
+  "version": "2.10.0"
 }

--- a/custom_components/haapi/resolve.py
+++ b/custom_components/haapi/resolve.py
@@ -1,0 +1,56 @@
+"""Resolve an automation/service target to HAAPI endpoint API callers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.target import (
+    TargetSelection,
+    async_extract_referenced_entity_ids,
+)
+
+from .const import DOMAIN
+
+
+def endpoint_callers(hass: HomeAssistant, target: dict[str, Any] | None) -> list:
+    """Return the HAAPI API callers for the endpoints referenced by a target.
+
+    ``target`` is a dict with the usual target keys (device_id / entity_id /
+    area_id / floor_id / label_id). HAAPI endpoints are devices, so any of those
+    that resolve to a HAAPI endpoint device yield that endpoint's API caller.
+    """
+    if not target:
+        return []
+    selection = TargetSelection(target)
+    if not selection.has_any_target:
+        return []
+
+    selected = async_extract_referenced_entity_ids(hass, selection)
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    device_ids: set[str] = set(selected.referenced_devices)
+    for entity_id in selected.referenced | selected.indirectly_referenced:
+        entry = ent_reg.async_get(entity_id)
+        if entry and entry.device_id:
+            device_ids.add(entry.device_id)
+
+    domain_data = hass.data.get(DOMAIN, {})
+    callers: list = []
+    for device_id in device_ids:
+        device = dev_reg.async_get(device_id)
+        if not device:
+            continue
+        for domain, identifier in device.identifiers:
+            if domain != DOMAIN:
+                continue
+            entry_id, _, endpoint_id = identifier.partition("_")
+            coordinator = domain_data.get(entry_id)
+            if coordinator is None:
+                continue
+            caller = coordinator.get_api_caller(endpoint_id)
+            if caller is not None:
+                callers.append(caller)
+    return callers

--- a/custom_components/haapi/services.yaml
+++ b/custom_components/haapi/services.yaml
@@ -1,0 +1,4 @@
+request:
+  target:
+    device:
+      integration: haapi

--- a/custom_components/haapi/services.yaml
+++ b/custom_components/haapi/services.yaml
@@ -1,4 +1,5 @@
 request:
   target:
-    device:
+    entity:
       integration: haapi
+      domain: button

--- a/custom_components/haapi/strings.json
+++ b/custom_components/haapi/strings.json
@@ -253,5 +253,12 @@
         }
       }
     }
+  },
+  "services": {
+    "request": {
+      "name": "Request",
+      "description": "Call a HAAPI endpoint and return its response (status, ok, body, headers) for use with response_variable.",
+      "fields": {}
+    }
   }
 }

--- a/custom_components/haapi/translations/en.json
+++ b/custom_components/haapi/translations/en.json
@@ -253,5 +253,12 @@
         }
       }
     }
+  },
+  "services": {
+    "request": {
+      "name": "Request",
+      "description": "Call a HAAPI endpoint and return its response (status, ok, body, headers) for use with response_variable.",
+      "fields": {}
+    }
   }
 }

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -35,6 +35,7 @@ async def endpoint(hass, mock_config_entry_data, mock_config_entry_options):
     device = dr.async_get(hass).async_get_device(
         identifiers={(DOMAIN, f"{entry.entry_id}_{_ENDPOINT_ID}")}
     )
+    assert device is not None, "HAAPI endpoint device was not created"
     return SimpleNamespace(caller=caller, device_id=device.id)
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,70 @@
+"""Tests for the HAAPI request service."""
+
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haapi.const import (
+    ATTR_BODY,
+    ATTR_ENDPOINT_NAME,
+    ATTR_OK,
+    ATTR_STATUS,
+    DOMAIN,
+)
+
+from tests.helpers import make_response, make_session
+
+_ENDPOINT_ID = "test-endpoint-id"
+
+
+@pytest.fixture
+async def loaded(hass, mock_config_entry_data, mock_config_entry_options):
+    """Set up a loaded entry; return its device id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_config_entry_data,
+        options=mock_config_entry_options,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.haapi.Store.async_load", return_value={}):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    device = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, f"{entry.entry_id}_{_ENDPOINT_ID}")}
+    )
+    return device.id
+
+
+async def test_request_returns_response(hass: HomeAssistant, loaded) -> None:
+    session = make_session(
+        make_response(200, '{"state": "FINISH"}', {"Content-Type": "application/json"})
+    )
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await hass.services.async_call(
+            DOMAIN,
+            "request",
+            {"device_id": [loaded]},
+            blocking=True,
+            return_response=True,
+        )
+
+    assert result[ATTR_STATUS] == 200
+    assert result[ATTR_OK] is True
+    assert result[ATTR_BODY] == '{"state": "FINISH"}'
+    assert result[ATTR_ENDPOINT_NAME] == "Test Endpoint"
+
+
+async def test_request_unresolvable_target_raises(hass: HomeAssistant, loaded) -> None:
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "request",
+            {"device_id": ["does-not-exist"]},
+            blocking=True,
+            return_response=True,
+        )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37,6 +37,7 @@ async def loaded(hass, mock_config_entry_data, mock_config_entry_options):
     device = dr.async_get(hass).async_get_device(
         identifiers={(DOMAIN, f"{entry.entry_id}_{_ENDPOINT_ID}")}
     )
+    assert device is not None, "HAAPI endpoint device was not created"
     return device.id
 
 
@@ -45,12 +46,14 @@ async def test_request_returns_response(hass: HomeAssistant, loaded) -> None:
         make_response(200, '{"state": "FINISH"}', {"Content-Type": "application/json"})
     )
     with patch("aiohttp.ClientSession", return_value=session):
+        # Call via target= (the real-automation path: HA merges target into
+        # call.data), not service_data, so this exercises how it's actually used.
         result = await hass.services.async_call(
             DOMAIN,
             "request",
-            {"device_id": [loaded]},
             blocking=True,
             return_response=True,
+            target={"device_id": [loaded]},
         )
 
     assert result[ATTR_STATUS] == 200
@@ -64,7 +67,7 @@ async def test_request_unresolvable_target_raises(hass: HomeAssistant, loaded) -
         await hass.services.async_call(
             DOMAIN,
             "request",
-            {"device_id": ["does-not-exist"]},
             blocking=True,
             return_response=True,
+            target={"device_id": ["does-not-exist"]},
         )


### PR DESCRIPTION
## What
Adds a **`haapi.request`** service that calls a single targeted endpoint and **returns its response** (`supports_response`). This is the synchronous counterpart to the fire-and-forget Trigger button, and it removes the need for the button + `wait_for_trigger`/`delay` pattern — which has a real **press-then-wait race** (the call's `haapi_response` can fire before `wait_for_trigger` arms, → timeout).

```yaml
- action: haapi.request
  target:
    device_id: <endpoint device>
  response_variable: result
# result -> {endpoint_id, endpoint_name, status, ok, body, headers, truncated}
- condition: "{{ result.ok }}"
```

## How
- Registered in `async_setup` with `SupportsResponse.ONLY`. The target must resolve to **exactly one** HAAPI endpoint device, else a `ServiceValidationError` with a clear message.
- Target → API-caller resolution is extracted to a shared `custom_components/haapi/resolve.py`; `condition.py` is refactored onto it (single source of truth, no behavior change — condition tests unchanged and green).
- `services.yaml` + `strings.json`/`en` + README added; version → **2.10.0**.

## Tests
`tests/test_service.py`: the service returns the response payload (mocked HTTP), and an unresolvable target raises `ServiceValidationError`. **Suite: 48 passed**; CI on this PR.

## Why it matters
Makes "call an endpoint and use its result" a single, race-free automation step. The Bambuddy clear-plate automation (currently failing on the press-then-wait race) will be rewritten onto this.