### PR TITLE
Fix: haapi.request should be SupportsResponse.OPTIONAL (2.10.1)

### DIFF
--- a/custom_components/haapi/__init__.py
+++ b/custom_components/haapi/__init__.py
@@ -112,7 +112,10 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
         DOMAIN,
         SERVICE_REQUEST,
         _async_handle_request,
-        supports_response=SupportsResponse.ONLY,
+        # OPTIONAL, not ONLY: the action is used both to capture the response
+        # (response_variable) and to fire-and-forget (e.g. a POST that just
+        # acts); ONLY would force every caller to capture the response.
+        supports_response=SupportsResponse.OPTIONAL,
     )
     return True
 

--- a/custom_components/haapi/manifest.json
+++ b/custom_components/haapi/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nasawa/HAAPI/issues",
   "requirements": [],
-  "version": "2.10.0"
+  "version": "2.10.1"
 }

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -62,6 +62,27 @@ async def test_request_returns_response(hass: HomeAssistant, loaded) -> None:
     assert result[ATTR_ENDPOINT_NAME] == "Test Endpoint"
 
 
+async def test_request_without_capturing_response(hass: HomeAssistant, loaded) -> None:
+    """The action is OPTIONAL-response: a fire-and-forget call (no
+    return_response / response_variable) must succeed, not error.
+
+    This is the clear-plate case — without it, SupportsResponse.ONLY would make
+    HA reject the call ("requires response_variable").
+    """
+    session = make_session(make_response(204, ""))
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await hass.services.async_call(
+            DOMAIN,
+            "request",
+            blocking=True,
+            target={"device_id": [loaded]},
+        )
+
+    # No response requested -> None returned, but the call still happened.
+    assert result is None
+    assert session.request.called
+
+
 async def test_request_unresolvable_target_raises(hass: HomeAssistant, loaded) -> None:
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(


### PR DESCRIPTION
## Bug
`haapi.request` was registered with `SupportsResponse.ONLY`, which forces **every** caller to capture the response. A fire-and-forget call — e.g. a clear-plate `POST` with no `response_variable` — errors:

> Script requires 'response_variable' for response data for service call haapi.request

Found live: a two-step automation (`haapi.request` status with `response_variable`, then `haapi.request` clear-plate without) failed on the second step.

## Fix
`supports_response=SupportsResponse.OPTIONAL` — a request action is legitimately used both ways: capture the result (GET status) **or** just act (POST). OPTIONAL supports both.

## Tests
Added a test that calls the service **without** `return_response` and asserts it succeeds (returns `None`) and still performs the call — the exact path `ONLY` rejected, and the one the original test missed (it only covered the capture path). Suite green.

Version → 2.10.1. (Needs a redeploy + HA restart to take effect, since the service registers in `async_setup`.)